### PR TITLE
Auto-download selected models and expand MLX correction output

### DIFF
--- a/Sources/mlx_semantic_correct.py
+++ b/Sources/mlx_semantic_correct.py
@@ -56,7 +56,7 @@ def main():
             prompt = f"{system_prompt}\n\n{user_text}"
 
         # Constrain output to be short relative to input to reduce risk of hallucination
-        max_tokens = max(32, min(256, int(len(user_text.split()) * 2)))
+        max_tokens = max(32, min(4096, int(len(user_text.split()) * 2)))
         try:
             text = generate(
                 model,

--- a/Tests/MLXScriptTests.swift
+++ b/Tests/MLXScriptTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+
+final class MLXScriptTests: XCTestCase {
+    func testMaxTokensLimit() throws {
+        let scriptURL = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent() // drop file name
+            .deletingLastPathComponent() // drop Tests directory
+            .appendingPathComponent("Sources/mlx_semantic_correct.py")
+        let content = try String(contentsOf: scriptURL)
+        XCTAssertTrue(content.contains("min(4096"), "Script should cap generation at 4096 tokens")
+    }
+}

--- a/Tests/ParakeetDownloadTests.swift
+++ b/Tests/ParakeetDownloadTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+
+final class ParakeetDownloadTests: XCTestCase {
+    func testParakeetDownloadUsesParakeetMLX() throws {
+        let managerURL = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/MLXModelManager.swift")
+        let content = try String(contentsOf: managerURL)
+        XCTAssertTrue(content.contains("parakeet_mlx"), "Parakeet download should import parakeet_mlx")
+        XCTAssertTrue(content.contains("parakeet-tdt-0.6b-v2"), "Parakeet repo string should be present")
+    }
+}


### PR DESCRIPTION
## Summary
- Preload Parakeet weights when Parakeet provider is chosen
- Teach MLX model manager to detect and fetch Parakeet models
- Test MLX manager for presence of Parakeet download script

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/argmaxinc/WhisperKit.git: CONNECT tunnel failed, response 403)*
- `swift test --parallel --enable-code-coverage` *(fails: Failed to clone repository https://github.com/argmaxinc/WhisperKit.git: CONNECT tunnel failed, response 403)*
- `python3 test_semantic_correction.py` *(fails: [Errno 2] No such file or directory: '/root/Library/Application Support/AudioWhisper/python_project/.venv/bin/python3')*


------
https://chatgpt.com/codex/tasks/task_b_68b4479280e0833095e4428f847ef751