### PR TITLE
Allow Option+Space as a valid custom hotkey

### DIFF
--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1405,6 +1405,12 @@ struct DownloadingView: View {
     }
 }
 
+// TODO: Consider migrating to sindresorhus/KeyboardShortcuts library
+// (https://github.com/sindresorhus/KeyboardShortcuts) which is the de facto
+// standard for macOS hotkey recording. It provides battle-tested validation,
+// built-in conflict detection with system/menu shortcuts, and would allow
+// removing this custom implementation (~300 lines). Used by VoiceInk, Maccy,
+// Amethyst, and other popular macOS apps.
 struct HotKeyRecorderView: View {
     @Binding var isRecording: Bool
     @Binding var recordedModifiers: NSEvent.ModifierFlags
@@ -1521,8 +1527,9 @@ struct HotKeyRecorderView: View {
             return false
         }
         
-        // Single modifier keys (like just shift) should require Command or Control
-        if modifiers == .shift || modifiers == .option {
+        // Shift-only combinations conflict with typing (e.g., Shift+A = "A")
+        // Option-only combinations like Option+Space are valid and commonly used
+        if modifiers == .shift {
             return false
         }
         


### PR DESCRIPTION
## Summary
- Fix hotkey validation to allow Option-only key combinations like Option+Space, which are commonly used in macOS apps
- Add TODO comment recommending migration to sindresorhus/KeyboardShortcuts library

## Problem
The custom hotkey recorder was rejecting Option+Space with "Invalid combination" error. This was overly restrictive - Option+Space is a valid hotkey used by many popular apps (Amazon Bedrock Client uses it as their default).

## Solution
Changed the validation logic to only block Shift-only combinations (which conflict with typing uppercase letters) while allowing Option-only combinations.

## Research
Analyzed how popular macOS apps handle this:
- **sindresorhus/KeyboardShortcuts** (de facto standard): Allows Option+Space
- **VoiceInk** (competitor app): Uses KeyboardShortcuts, allows Option+Space
- **Amazon Bedrock Client**: Option+Space is their **default** hotkey
- **Maccy, Amethyst**: All allow Option-only combinations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates hotkey validation to allow Option-only combos (e.g., ⌥Space) while still rejecting Shift-only, and adds a TODO to consider migrating to `KeyboardShortcuts`.
> 
> - **Hotkey validation (`Sources/SettingsView.swift`)**:
>   - Allow Option-only combinations (e.g., `⌥Space`) by removing the `.option` restriction.
>   - Continue rejecting Shift-only combos to avoid conflicts with typing.
> - **Maintenance**:
>   - Add TODO to consider migrating to `sindresorhus/KeyboardShortcuts` for hotkey recording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79ac6993442cd1b0a03e25682dea6650ba0defd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->