### PR TITLE
feat: Add configurable OpenAI model name support

### DIFF
--- a/Sources/Services/SpeechToTextService.swift
+++ b/Sources/Services/SpeechToTextService.swift
@@ -153,12 +153,16 @@ internal class SpeechToTextService {
 
         let transcriptionURL = openAITranscriptionEndpoint
 
+        // Get model name from UserDefaults, defaulting to "whisper-1"
+        let modelName = UserDefaults.standard.string(forKey: "openAIModel")?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let model = (modelName?.isEmpty == false) ? modelName! : "whisper-1"
+
         return try await withCheckedThrowingContinuation { continuation in
             AF.upload(
                 multipartFormData: { multipartFormData in
                     multipartFormData.append(audioURL, withName: "file")
-                    // Azure deployments already specify the model, but it doesn't hurt to include
-                    multipartFormData.append("whisper-1".data(using: .utf8)!, withName: "model")
+                    // Use configured model or default to whisper-1
+                    multipartFormData.append(model.data(using: .utf8)!, withName: "model")
                 },
                 to: transcriptionURL,
                 headers: headers

--- a/Sources/Views/Dashboard/DashboardProvidersView.swift
+++ b/Sources/Views/Dashboard/DashboardProvidersView.swift
@@ -9,6 +9,7 @@ internal struct DashboardProvidersView: View {
     @AppStorage("hasSetupParakeet") var hasSetupParakeet = false
     @AppStorage("hasSetupLocalLLM") var hasSetupLocalLLM = false
     @AppStorage("openAIBaseURL") var openAIBaseURL = ""
+    @AppStorage("openAIModel") var openAIModel = "whisper-1"
     @AppStorage("geminiBaseURL") var geminiBaseURL = ""
     @AppStorage("maxModelStorageGB") var maxModelStorageGB = 5.0
     
@@ -784,7 +785,26 @@ internal struct DashboardProvidersView: View {
                                     .stroke(DashboardTheme.rule, lineWidth: 1)
                             )
                     }
-                    
+
+                    VStack(alignment: .leading, spacing: DashboardTheme.Spacing.xs) {
+                        Text("OpenAI Model")
+                            .font(DashboardTheme.Fonts.sans(11, weight: .medium))
+                            .foregroundStyle(DashboardTheme.inkMuted)
+
+                        TextField("whisper-1", text: $openAIModel)
+                            .textFieldStyle(.plain)
+                            .font(DashboardTheme.Fonts.mono(12, weight: .regular))
+                            .padding(DashboardTheme.Spacing.sm)
+                            .background(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(DashboardTheme.pageBg)
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .stroke(DashboardTheme.rule, lineWidth: 1)
+                            )
+                    }
+
                     VStack(alignment: .leading, spacing: DashboardTheme.Spacing.xs) {
                         Text("Gemini")
                             .font(DashboardTheme.Fonts.sans(11, weight: .medium))


### PR DESCRIPTION
## Summary

This PR adds the ability to configure the OpenAI model used for transcription, instead of the hardcoded `whisper-1`. Users can now specify custom models like `gpt-4o-transcribe` or `gpt-4o-audio-preview` through the settings UI.

## Motivation

- OpenAI has released newer audio models beyond `whisper-1`
- Users with custom API proxies may want to use different model names
- The hardcoded model name prevented flexibility without code changes

## Changes

### UI Changes
- Added "OpenAI Model" input field in Advanced Settings section
- Field defaults to `whisper-1` for backward compatibility

### Code Changes
- Added `@AppStorage("openAIModel")` in `DashboardProvidersView.swift`
- Modified `SpeechToTextService.swift` to read model name from `UserDefaults`
- Maintains backward compatibility by defaulting to `whisper-1` if not set

## Testing

Tested with:
- Default behavior (`whisper-1`)
- Custom model name (`gpt-4o-transcribe`)
- Empty/whitespace handling (falls back to default)

## Screenshots

The new "OpenAI Model" field appears in Advanced Settings below the OpenAI base URL field.

## Backward Compatibility

✅ Fully backward compatible - existing users will continue using `whisper-1` by default.