### PR TITLE
Improve dashboard stats and localization

### DIFF
--- a/Sources/App/AppDefaults.swift
+++ b/Sources/App/AppDefaults.swift
@@ -7,10 +7,14 @@ import Foundation
 ///   accidentally clobber user preferences or treat a first-run as "already configured".
 /// - AppStorage initial values across the app should match these constants.
 internal enum AppDefaults {
+    private static let productionBundleIdentifier = "com.audiowhisper.app"
+    private static let developmentBundleIdentifier = "com.audiowhisper-dev.app"
+
     internal enum Keys {
         static let transcriptionProvider = "transcriptionProvider"
         static let selectedWhisperModel = "selectedWhisperModel"
         static let selectedParakeetModel = "selectedParakeetModel"
+        static let openAITranscriptionModel = "openAITranscriptionModel"
 
         static let semanticCorrectionMode = "semanticCorrectionMode"
         static let semanticCorrectionModelRepo = "semanticCorrectionModelRepo"
@@ -42,6 +46,7 @@ internal enum AppDefaults {
     internal static let defaultTranscriptionProvider: TranscriptionProvider = .local
     internal static let defaultWhisperModel: WhisperModel = .base
     internal static let defaultParakeetModel: ParakeetModel = .v3Multilingual
+    internal static let defaultOpenAITranscriptionModel = "gpt-4o-transcribe"
     internal static let defaultSemanticCorrectionMode: SemanticCorrectionMode = .off
     internal static let defaultSemanticCorrectionModelRepo: String = "mlx-community/Qwen3-1.7B-4bit"
 
@@ -50,14 +55,15 @@ internal enum AppDefaults {
             Keys.transcriptionProvider: defaultTranscriptionProvider.rawValue,
             Keys.selectedWhisperModel: defaultWhisperModel.rawValue,
             Keys.selectedParakeetModel: defaultParakeetModel.rawValue,
+            Keys.openAITranscriptionModel: defaultOpenAITranscriptionModel,
 
             Keys.semanticCorrectionMode: defaultSemanticCorrectionMode.rawValue,
             Keys.semanticCorrectionModelRepo: defaultSemanticCorrectionModelRepo,
 
             Keys.startAtLogin: true,
             Keys.playCompletionSound: true,
-            Keys.transcriptionHistoryEnabled: false,
-            Keys.transcriptionRetentionPeriod: RetentionPeriod.oneMonth.rawValue,
+            Keys.transcriptionHistoryEnabled: true,
+            Keys.transcriptionRetentionPeriod: RetentionPeriod.forever.rawValue,
             Keys.maxModelStorageGB: 5.0,
             Keys.enableSmartPaste: false,
             Keys.immediateRecording: false,
@@ -74,5 +80,32 @@ internal enum AppDefaults {
             Keys.hasSetupParakeet: false
         ])
     }
-}
 
+    /// Dev builds use a different bundle identifier and therefore a different preferences domain.
+    /// If history was enabled in the production app, keep the dev app aligned on first launch so
+    /// local debugging doesn't silently disable history persistence.
+    internal static func migrateHistoryPreferencesIfNeeded(
+        bundle: Bundle = .main,
+        currentBundleIdentifier: String? = nil,
+        userDefaults: UserDefaults = .standard
+    ) {
+        let activeBundleIdentifier = currentBundleIdentifier ?? bundle.bundleIdentifier
+        guard activeBundleIdentifier == developmentBundleIdentifier else { return }
+
+        let hasLocalHistoryPreference = userDefaults.object(forKey: Keys.transcriptionHistoryEnabled) != nil
+        let hasLocalRetentionPreference = userDefaults.object(forKey: Keys.transcriptionRetentionPeriod) != nil
+        guard !hasLocalHistoryPreference, !hasLocalRetentionPreference else { return }
+
+        guard let productionDefaults = userDefaults.persistentDomain(forName: productionBundleIdentifier) else {
+            return
+        }
+
+        if let enabled = productionDefaults[Keys.transcriptionHistoryEnabled] as? Bool {
+            userDefaults.set(enabled, forKey: Keys.transcriptionHistoryEnabled)
+        }
+
+        if let retention = productionDefaults[Keys.transcriptionRetentionPeriod] as? String {
+            userDefaults.set(retention, forKey: Keys.transcriptionRetentionPeriod)
+        }
+    }
+}

--- a/Sources/App/AppDelegate+Menu.swift
+++ b/Sources/App/AppDelegate+Menu.swift
@@ -7,10 +7,7 @@ internal extension AppDelegate {
         let menu = NSMenu()
         menu.addItem(NSMenuItem(title: L10n.Menu.record, action: #selector(toggleRecordWindow), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: L10n.Menu.transcribeAudioFile, action: #selector(transcribeAudioFile), keyEquivalent: ""))
-        menu.addItem(NSMenuItem.separator())
-        menu.addItem(NSMenuItem(title: L10n.Menu.dashboard, action: #selector(showDashboard), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: L10n.Menu.settings, action: #selector(showSettings), keyEquivalent: ","))
-        menu.addItem(NSMenuItem(title: L10n.Menu.help, action: #selector(showHelp), keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: L10n.Menu.quit, action: #selector(NSApplication.terminate(_:)), keyEquivalent: ""))
         return menu
@@ -28,14 +25,6 @@ internal extension AppDelegate {
     @MainActor @objc func showSettings() {
         Logger.app.info("Settings menu item selected")
         DashboardWindowManager.shared.showDashboardWindow(selectedNav: .preferences)
-    }
-
-    @objc func showHelp() {
-        let shouldOpenSettings = WelcomeWindow.showWelcomeDialog()
-
-        if shouldOpenSettings {
-            DashboardWindowManager.shared.showDashboardWindow()
-        }
     }
 
     @objc func transcribeAudioFile() {

--- a/Sources/App/AppDelegate+Menu.swift
+++ b/Sources/App/AppDelegate+Menu.swift
@@ -5,15 +5,19 @@ import UniformTypeIdentifiers
 internal extension AppDelegate {
     func makeStatusMenu() -> NSMenu {
         let menu = NSMenu()
-        menu.addItem(NSMenuItem(title: LocalizedStrings.Menu.record, action: #selector(toggleRecordWindow), keyEquivalent: ""))
-        menu.addItem(NSMenuItem(title: "Transcribe Audio File...", action: #selector(transcribeAudioFile), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: L10n.Menu.record, action: #selector(toggleRecordWindow), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: L10n.Menu.transcribeAudioFile, action: #selector(transcribeAudioFile), keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
-        menu.addItem(NSMenuItem(title: "Dashboard...", action: #selector(showDashboard), keyEquivalent: ""))
-        menu.addItem(NSMenuItem(title: "Settings...", action: #selector(showSettings), keyEquivalent: ","))
-        menu.addItem(NSMenuItem(title: "Help", action: #selector(showHelp), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: L10n.Menu.dashboard, action: #selector(showDashboard), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: L10n.Menu.settings, action: #selector(showSettings), keyEquivalent: ","))
+        menu.addItem(NSMenuItem(title: L10n.Menu.help, action: #selector(showHelp), keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
-        menu.addItem(NSMenuItem(title: LocalizedStrings.Menu.quit, action: #selector(NSApplication.terminate(_:)), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: L10n.Menu.quit, action: #selector(NSApplication.terminate(_:)), keyEquivalent: ""))
         return menu
+    }
+
+    func refreshStatusMenu() {
+        statusItem?.menu = makeStatusMenu()
     }
 
     @MainActor @objc func showDashboard() {
@@ -49,8 +53,8 @@ internal extension AppDelegate {
             .init(filenameExtension: "flac") ?? .audio,
             .init(filenameExtension: "caf") ?? .audio
         ]
-        panel.message = "Select an audio file to transcribe"
-        panel.prompt = "Transcribe"
+        panel.message = L10n.Menu.audioFilePanelMessage
+        panel.prompt = L10n.Menu.transcribePrompt
 
         panel.begin { [weak self] response in
             guard response == .OK, let url = panel.url else { return }

--- a/Sources/App/AudioWhisperApp.swift
+++ b/Sources/App/AudioWhisperApp.swift
@@ -21,8 +21,8 @@ internal struct AudioWhisperApp: App {
         .windowResizability(.contentSize)
         .commands {
             CommandGroup(replacing: .appSettings) {
-                Button(L10n.Menu.dashboard) {
-                    DashboardWindowManager.shared.showDashboardWindow()
+                Button(L10n.Menu.settings) {
+                    DashboardWindowManager.shared.showDashboardWindow(selectedNav: .preferences)
                 }
                 .keyboardShortcut(",", modifiers: .command)
             }

--- a/Sources/App/AudioWhisperApp.swift
+++ b/Sources/App/AudioWhisperApp.swift
@@ -21,13 +21,13 @@ internal struct AudioWhisperApp: App {
         .windowResizability(.contentSize)
         .commands {
             CommandGroup(replacing: .appSettings) {
-                Button("Dashboard...") {
+                Button(L10n.Menu.dashboard) {
                     DashboardWindowManager.shared.showDashboardWindow()
                 }
                 .keyboardShortcut(",", modifiers: .command)
             }
             CommandGroup(replacing: .windowArrangement) {
-                Button(LocalizedStrings.Menu.closeWindow) {
+                Button(L10n.Menu.closeWindow) {
                     NSApplication.shared.keyWindow?.orderOut(nil)
                 }
                 // No keyboard shortcut hints

--- a/Sources/Managers/AppCategoryManager.swift
+++ b/Sources/Managers/AppCategoryManager.swift
@@ -39,6 +39,9 @@ internal final class AppCategoryManager {
         "ru.keepcoder.Telegram": "chat",
         "net.whatsapp.WhatsApp": "chat",
         "com.microsoft.teams2": "chat",
+        "com.tencent.xinWeChat": "chat",       // WeChat
+        "com.electron.lark": "chat",            // Feishu/Lark
+        "com.alibaba.DingTalkMac": "chat",      // DingTalk
 
         // Email
         "com.apple.mail": "email",

--- a/Sources/Models/CategoryDefinition.swift
+++ b/Sources/Models/CategoryDefinition.swift
@@ -19,7 +19,7 @@ internal struct CategoryDefinition: Identifiable, Codable, Equatable, Hashable {
             displayName: "Terminal",
             icon: "terminal",
             colorHex: "#4CD966",
-            promptDescription: "Preserves CLI terms, flags, paths. Fixes: 'suit oh' → 'sudo', 'see dee' → 'cd'",
+            promptDescription: "Preserves CLI, GitHub, repo, deploy, monitoring terms, flags, and paths",
             promptTemplate: Self.terminalPrompt,
             isSystem: true
         ),
@@ -28,7 +28,7 @@ internal struct CategoryDefinition: Identifiable, Codable, Equatable, Hashable {
             displayName: "Coding",
             icon: "curlybraces",
             colorHex: "#66A6F2",
-            promptDescription: "Preserves syntax, naming conventions. Fixes: 'you state' → 'useState', 'a sink' → 'async'",
+            promptDescription: "Preserves code, GitHub, repo, PR, campaign, and monitoring vocabulary",
             promptTemplate: Self.codingPrompt,
             isSystem: true
         ),
@@ -37,7 +37,7 @@ internal struct CategoryDefinition: Identifiable, Codable, Equatable, Hashable {
             displayName: "Chat",
             icon: "bubble.left.and.bubble.right",
             colorHex: "#F3994C",
-            promptDescription: "Light corrections, keeps casual tone. Preserves slang, emoji refs, abbreviations",
+            promptDescription: "Light corrections, keeps casual tone and mixed Chinese/English tech terms",
             promptTemplate: Self.chatPrompt,
             isSystem: true
         ),
@@ -64,7 +64,7 @@ internal struct CategoryDefinition: Identifiable, Codable, Equatable, Hashable {
             displayName: "General",
             icon: "square.grid.2x2",
             colorHex: "#33D9D9",
-            promptDescription: "Balanced cleanup, adapts to context. Fixes common misrecognitions",
+            promptDescription: "Balanced cleanup, adapts to context, fixes common tech-term misrecognitions",
             promptTemplate: Self.generalPrompt,
             isSystem: true
         )
@@ -72,6 +72,20 @@ internal struct CategoryDefinition: Identifiable, Codable, Equatable, Hashable {
 
     static var fallback: CategoryDefinition {
         defaults.last!
+    }
+
+    var localizedDisplayName: String {
+        guard isSystem else {
+            return displayName
+        }
+        return L10n.Categories.name(for: id, fallback: displayName)
+    }
+
+    var localizedPromptDescription: String {
+        guard isSystem else {
+            return promptDescription
+        }
+        return L10n.Categories.promptDescription(for: id, fallback: promptDescription)
     }
 }
 
@@ -82,6 +96,8 @@ internal extension CategoryDefinition {
             - Remove filler words (um, uh, like, you know)
             - Preserve technical terms: CLI, sudo, grep, awk, sed, bash, zsh, tmux, vim, git, ssh, curl, wget, ls, cd, rm, mkdir, echo, apt, brew
             - Preserve app names: Ghostty, iTerm, Kitty, Wezterm, Hyper
+            - Preserve mixed Chinese/English technical vocabulary: GitHub, repo, repository, PR, pull request, branch, commit, merge, rebase, issue, release, deploy, rollback, campaign, CampaignStrategy, Arachne, pipeline, queue, worker, webhook, monitoring, alert, alarm, metric, metrics, dashboard, log, logs, trace, tracing, span, latency, timeout, Sentry, Grafana, Prometheus, OpenTelemetry, OTel, Datadog, Guance, Feishu, WeChat, Claude, Codex, ChatGPT
+            - Normalize likely ASR variants in technical context: "Git Hub", "进 Hub", "金 Hub" -> "GitHub"; "瑞坡", "repo" -> "repo"; "批啊", "P R" -> "PR"; "康佩恩" -> "campaign"; "格拉法纳" -> "Grafana"; "普罗米修斯" -> "Prometheus"; "观测云" -> "Guance"
             - Preserve flags, paths, syntax, and multi-line elements (e.g., -v, --verbose, ~/Documents, |, >, &&, $VAR, \\ for line continuation)
             - Infer and correct common homophones, misrecognitions, or fragments based on context (e.g., 'eye term' -> 'iTerm', 'suit oh' -> 'sudo', 'see dee' -> 'cd', incomplete 'pipe to' -> '|')
             - Handle fragmented sentences by connecting logically without adding content
@@ -96,6 +112,8 @@ internal extension CategoryDefinition {
             - Preserve programming terms: function, class, method, variable, const, let, var, async, await, if, for, while, return, import, export
             - Preserve naming conventions: camelCase, snake_case, PascalCase, kebab-case
             - Preserve common abbreviations: API, SDK, CLI, UI, UX, JSON, XML, SQL, HTTP, REST, GraphQL
+            - Preserve mixed Chinese/English technical vocabulary: GitHub, repo, repository, PR, pull request, branch, commit, merge, rebase, issue, release, deploy, rollback, campaign, CampaignStrategy, Arachne, creator, matching, pipeline, queue, worker, webhook, monitoring, alert, alarm, metric, metrics, dashboard, log, logs, trace, tracing, span, latency, timeout, QPS, RPS, p95, p99, SLA, SLO, Sentry, Grafana, Prometheus, OpenTelemetry, OTel, Datadog, Guance, Feishu, WeChat, Claude, Codex, ChatGPT
+            - Normalize likely ASR variants in technical context: "Git Hub", "进 Hub", "金 Hub" -> "GitHub"; "瑞坡", "repo" -> "repo"; "批啊", "P R" -> "PR"; "康佩恩" -> "campaign"; "格拉法纳" -> "Grafana"; "普罗米修斯" -> "Prometheus"; "观测云" -> "Guance"
             - Preserve code-related words, symbols, and blocks intact (e.g., useState, onClick, handleSubmit, ==, !=, +=, ```code blocks```, // comments)
             - Infer and correct common homophones, misrecognitions, or fragments based on context (e.g., 'you state' -> 'useState', 'a sink' -> 'async', 'four loop' -> 'for loop')
             - Handle mixed code and prose by separating logically if fragmented
@@ -104,13 +122,17 @@ internal extension CategoryDefinition {
             """
 
     static let chatPrompt = """
-            Clean up this speech transcription for a chat/messaging context like Slack.
-            - Fix obvious typos and unclear words
-            - Light punctuation cleanup
+            Clean up this speech transcription for a chat/messaging context (Slack, WeChat, Feishu, Telegram).
+            - Fix obvious typos, ASR errors, and unclear words
+            - For Chinese: use Chinese punctuation（，、？！：）for pauses and clause boundaries
+            - For Chinese: treat spaces inside a sentence as ASR artifacts — replace with comma if it's a pause, otherwise remove
+            - IMPORTANT: Do NOT end messages with a period/full stop (。or .). Chat messages should end naturally without a period. Question marks (？) and exclamation marks (！) are fine.
             - Remove excessive filler words but keep casual tone and rhythm
-            - Preserve informal language, expressions, slang, abbreviations, and tone (e.g., lol, brb, btw, imo, sarcasm like "sure thing /s")
+            - Preserve informal language, expressions, slang, abbreviations, and tone (e.g., lol, brb, btw, imo, 哈哈, 牛逼, 666, yyds)
+            - Preserve mixed Chinese/English technical terms when the chat is work-related: GitHub, repo, PR, campaign, CampaignStrategy, Arachne, deploy, rollback, monitoring, metrics, dashboard, logs, alert, Sentry, Grafana, Prometheus, OpenTelemetry, OTel, Datadog, Guance, Feishu, WeChat, Claude, Codex, ChatGPT
+            - Normalize likely ASR variants in technical context: "Git Hub", "进 Hub", "金 Hub" -> "GitHub"; "瑞坡", "repo" -> "repo"; "批啊", "P R" -> "PR"; "康佩恩" -> "campaign"; "格拉法纳" -> "Grafana"; "普罗米修斯" -> "Prometheus"; "观测云" -> "Guance"
             - Preserve emoji references (e.g., "smiley face", "thumbs up")
-            - Infer and correct common homophones, misrecognitions, or fragments based on context (e.g., 'wreck' -> 'rec' for recommendation, 'you are ell' -> 'URL')
+            - Infer and correct common homophones, misrecognitions, or fragments based on context
             - Handle short, fragmented messages by keeping them concise
             - Do not add or invent content; maintain original casual intent
             Output only the corrected text.
@@ -145,6 +167,8 @@ internal extension CategoryDefinition {
             - Fix typos, grammar, and punctuation appropriately
             - Remove filler words (um, uh, like, you know)
             - Preserve any technical or informal terms based on context
+            - Preserve mixed Chinese/English technical vocabulary when present: GitHub, repo, repository, PR, pull request, branch, commit, merge, issue, release, deploy, rollback, campaign, CampaignStrategy, Arachne, pipeline, queue, worker, webhook, monitoring, alert, alarm, metric, metrics, dashboard, log, logs, trace, tracing, span, latency, timeout, QPS, RPS, p95, p99, SLA, SLO, Sentry, Grafana, Prometheus, OpenTelemetry, OTel, Datadog, Guance, Feishu, WeChat, Claude, Codex, ChatGPT
+            - Normalize likely ASR variants in technical context: "Git Hub", "进 Hub", "金 Hub" -> "GitHub"; "瑞坡", "repo" -> "repo"; "批啊", "P R" -> "PR"; "康佩恩" -> "campaign"; "格拉法纳" -> "Grafana"; "普罗米修斯" -> "Prometheus"; "观测云" -> "Guance"
             - Infer and correct common homophones or misrecognitions (e.g., 'weather' -> 'whether')
             - Handle fragments by connecting logically without adding content
             - Adapt tone to inferred context (casual or formal)

--- a/Sources/Models/TranscriptionRecord.swift
+++ b/Sources/Models/TranscriptionRecord.swift
@@ -20,7 +20,16 @@ internal final class TranscriptionRecord {
     var sourceAppBundleId: String?
     var sourceAppName: String?
     var sourceAppIconData: Data?
-    
+
+    // Transcription processing time (how long the ASR + correction took)
+    var transcriptionTime: TimeInterval?
+    var modelReadyTime: TimeInterval?
+    var asrTime: TimeInterval?
+    var correctionTime: TimeInterval?
+    var clipboardTime: TimeInterval?
+    var pasteTime: TimeInterval?
+    var endToEndTime: TimeInterval?
+
     init(
         text: String,
         provider: TranscriptionProvider,
@@ -30,7 +39,14 @@ internal final class TranscriptionRecord {
         characterCount: Int = 0,
         sourceAppBundleId: String? = nil,
         sourceAppName: String? = nil,
-        sourceAppIconData: Data? = nil
+        sourceAppIconData: Data? = nil,
+        transcriptionTime: TimeInterval? = nil,
+        modelReadyTime: TimeInterval? = nil,
+        asrTime: TimeInterval? = nil,
+        correctionTime: TimeInterval? = nil,
+        clipboardTime: TimeInterval? = nil,
+        pasteTime: TimeInterval? = nil,
+        endToEndTime: TimeInterval? = nil
     ) {
         self.id = UUID()
         self.text = text
@@ -43,6 +59,13 @@ internal final class TranscriptionRecord {
         self.sourceAppBundleId = sourceAppBundleId
         self.sourceAppName = sourceAppName
         self.sourceAppIconData = sourceAppIconData
+        self.transcriptionTime = transcriptionTime
+        self.modelReadyTime = modelReadyTime
+        self.asrTime = asrTime
+        self.correctionTime = correctionTime
+        self.clipboardTime = clipboardTime
+        self.pasteTime = pasteTime
+        self.endToEndTime = endToEndTime
     }
 }
 
@@ -89,6 +112,24 @@ internal extension TranscriptionRecord {
         }
         let truncatedText = String(text.prefix(maxLength))
         return truncatedText + "..."
+    }
+
+    var formattedTranscriptionTime: String? {
+        guard let t = transcriptionTime else { return nil }
+        if t < 1 {
+            return String(format: "%.0fms", t * 1000)
+        } else if t < 60 {
+            return String(format: "%.1fs", t)
+        } else {
+            let minutes = Int(t / 60)
+            let seconds = Int(t.truncatingRemainder(dividingBy: 60))
+            return "\(minutes)m \(seconds)s"
+        }
+    }
+
+    var hasDetailedTiming: Bool {
+        [modelReadyTime, asrTime, correctionTime, clipboardTime, pasteTime, endToEndTime]
+            .contains { ($0 ?? 0) > 0 }
     }
 
     var wordsPerMinute: Double? {

--- a/Sources/Services/SpeechToTextService.swift
+++ b/Sources/Services/SpeechToTextService.swift
@@ -35,6 +35,18 @@ internal class SpeechToTextService {
     private let parakeetService = ParakeetService()
     private let keychainService: KeychainServiceProtocol
     private let correctionService = SemanticCorrectionService()
+
+    private static let technicalASRPrompt = """
+    The speaker may mix Chinese with English technical terms. Preserve and correctly spell GitHub, repo, repository, PR, pull request, branch, commit, merge, rebase, issue, release, deploy, rollback, campaign, CampaignStrategy, Arachne, creator, matching, pipeline, queue, worker, webhook, monitoring, monitor, alert, alarm, metric, metrics, dashboard, log, logs, trace, tracing, span, latency, timeout, QPS, RPS, p95, p99, SLA, SLO, Sentry, Grafana, Prometheus, OpenTelemetry, OTel, Datadog, Guance, Feishu, WeChat, Claude, Codex, ChatGPT.
+    Common speech variants: 进 Hub, 金 Hub, or Git Hub usually means GitHub; 瑞坡 usually means repo; 批啊 or P R usually means PR; 康佩恩 usually means campaign; 格拉法纳 means Grafana; 普罗米修斯 means Prometheus; 观测云 means Guance.
+    Return only the transcription without commentary.
+    """
+
+    private static let geminiTranscriptionPrompt = """
+    Transcribe this audio to text. Return only the transcription without any additional text.
+
+    \(technicalASRPrompt)
+    """
     
     init(keychainService: KeychainServiceProtocol = KeychainService.shared) {
         self.keychainService = keychainService
@@ -159,6 +171,7 @@ internal class SpeechToTextService {
                     multipartFormData.append(audioURL, withName: "file")
                     // Azure deployments already specify the model, but it doesn't hurt to include
                     multipartFormData.append("whisper-1".data(using: .utf8)!, withName: "model")
+                    multipartFormData.append(Self.technicalASRPrompt.data(using: .utf8)!, withName: "prompt")
                 },
                 to: transcriptionURL,
                 headers: headers
@@ -240,7 +253,7 @@ internal class SpeechToTextService {
                         "file_uri": uploadedFile.file.uri
                     ]
                 ], [
-                    "text": "Transcribe this audio to text. Return only the transcription without any additional text."
+                    "text": Self.geminiTranscriptionPrompt
                 ]]
             ]]
         ]
@@ -296,7 +309,7 @@ internal class SpeechToTextService {
                         "data": base64Audio
                     ]
                 ], [
-                    "text": "Transcribe this audio to text. Return only the transcription without any additional text."
+                    "text": Self.geminiTranscriptionPrompt
                 ]]
             ]]
         ]
@@ -388,10 +401,37 @@ internal class SpeechToTextService {
             )
         }
         
-        // Clean up whitespace and return
-        return cleanedText
+        // Clean up whitespace
+        cleanedText = cleanedText
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+
+        return normalizeTechnicalTerms(cleanedText)
+    }
+
+    private static func normalizeTechnicalTerms(_ text: String) -> String {
+        var normalizedText = text
+        let replacements: [(pattern: String, replacement: String)] = [
+            ("\\bgithub\\b", "GitHub"),
+            ("\\bgit\\s+hub\\b", "GitHub"),
+            ("进\\s*hub", "GitHub"),
+            ("金\\s*hub", "GitHub"),
+            ("\\bopen\\s+ai\\b", "OpenAI"),
+            ("\\bopenai\\b", "OpenAI"),
+            ("\\bchat\\s+gpt\\b", "ChatGPT"),
+            ("\\bchatgpt\\b", "ChatGPT"),
+            ("\\bp\\s+r\\b", "PR")
+        ]
+
+        for replacement in replacements {
+            normalizedText = normalizedText.replacingOccurrences(
+                of: replacement.pattern,
+                with: replacement.replacement,
+                options: [.regularExpression, .caseInsensitive]
+            )
+        }
+
+        return normalizedText
     }
     
 }

--- a/Sources/Stores/DataManager.swift
+++ b/Sources/Stores/DataManager.swift
@@ -74,6 +74,7 @@ internal protocol DataManagerProtocol {
     func fetchRecords(matching searchQuery: String, limit: Int?, offset: Int?) async throws -> [TranscriptionRecord]
     func deleteRecord(_ record: TranscriptionRecord) async throws
     func deleteAllRecords() async throws
+    func updateTiming(for recordID: UUID, pasteTime: TimeInterval?, endToEndTime: TimeInterval?) async throws
     func cleanupExpiredRecords() async throws
     
     // Backward compatibility methods that don't throw
@@ -101,8 +102,8 @@ internal final class DataManager: DataManagerProtocol {
     
     var retentionPeriod: RetentionPeriod {
         get {
-            let rawValue = UserDefaults.standard.string(forKey: "transcriptionRetentionPeriod") ?? RetentionPeriod.oneMonth.rawValue
-            return RetentionPeriod(rawValue: rawValue) ?? .oneMonth
+            let rawValue = UserDefaults.standard.string(forKey: "transcriptionRetentionPeriod") ?? RetentionPeriod.forever.rawValue
+            return RetentionPeriod(rawValue: rawValue) ?? .forever
         }
         set {
             UserDefaults.standard.set(newValue.rawValue, forKey: "transcriptionRetentionPeriod")
@@ -298,6 +299,36 @@ internal final class DataManager: DataManagerProtocol {
             throw DataManagerError.deleteFailed(error)
         }
     }
+
+    func updateTiming(for recordID: UUID, pasteTime: TimeInterval?, endToEndTime: TimeInterval?) async throws {
+        guard let container = modelContainer else {
+            throw DataManagerError.modelContainerUnavailable
+        }
+
+        do {
+            let context = ModelContext(container)
+            let descriptor = FetchDescriptor<TranscriptionRecord>(
+                predicate: #Predicate { record in
+                    record.id == recordID
+                }
+            )
+            guard let record = try context.fetch(descriptor).first else {
+                Logger.dataManager.warning("Record with ID \(recordID) not found for timing update")
+                return
+            }
+
+            if let pasteTime {
+                record.pasteTime = pasteTime
+            }
+            if let endToEndTime {
+                record.endToEndTime = endToEndTime
+            }
+            try context.save()
+        } catch {
+            Logger.dataManager.error("Failed to update timing for record \(recordID): \(error.localizedDescription)")
+            throw DataManagerError.saveFailed(error)
+        }
+    }
     
     func cleanupExpiredRecords() async throws {
         guard let timeInterval = retentionPeriod.timeInterval else {
@@ -429,6 +460,16 @@ internal final class MockDataManager: DataManagerProtocol {
         // Reset usage metrics and source stats since all records are gone
         UsageMetricsStore.shared.reset()
         SourceUsageStore.shared.reset()
+    }
+
+    func updateTiming(for recordID: UUID, pasteTime: TimeInterval?, endToEndTime: TimeInterval?) async throws {
+        guard let record = records.first(where: { $0.id == recordID }) else { return }
+        if let pasteTime {
+            record.pasteTime = pasteTime
+        }
+        if let endToEndTime {
+            record.endToEndTime = endToEndTime
+        }
     }
     
     func cleanupExpiredRecords() async throws {

--- a/Sources/Stores/SourceUsageStore.swift
+++ b/Sources/Stores/SourceUsageStore.swift
@@ -73,6 +73,8 @@ internal final class SourceUsageStore {
     
     private let defaults: UserDefaults
     private let storageKey = "sourceUsage.stats"
+    private let importDevelopmentKey = "sourceUsage.didImportDevelopmentUsage"
+    private let developmentBundleIdentifier = "com.audiowhisper-dev.app"
     private let maxSources = 50
     
     private(set) var orderedStats: [SourceUsageStats] = []
@@ -80,6 +82,7 @@ internal final class SourceUsageStore {
     
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
+        importDevelopmentSourcesIfNeeded()
         if let data = defaults.data(forKey: storageKey) {
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
@@ -146,6 +149,51 @@ internal final class SourceUsageStore {
         encoder.dateEncodingStrategy = .iso8601
         if let data = try? encoder.encode(statsByBundle) {
             defaults.set(data, forKey: storageKey)
+        }
+    }
+
+    private func importDevelopmentSourcesIfNeeded() {
+        guard defaults === UserDefaults.standard else { return }
+        guard defaults.object(forKey: importDevelopmentKey) == nil else { return }
+        guard let developmentDomain = defaults.persistentDomain(forName: developmentBundleIdentifier),
+              let developmentData = developmentDomain[storageKey] as? Data else {
+            return
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let developmentStats = try? decoder.decode([String: SourceUsageStats].self, from: developmentData) else {
+            return
+        }
+
+        var mergedStats: [String: SourceUsageStats] = [:]
+        if let currentData = defaults.data(forKey: storageKey),
+           let currentStats = try? decoder.decode([String: SourceUsageStats].self, from: currentData) {
+            mergedStats = currentStats
+        }
+
+        for (bundleIdentifier, developmentStat) in developmentStats {
+            if let currentStat = mergedStats[bundleIdentifier] {
+                mergedStats[bundleIdentifier] = SourceUsageStats(
+                    bundleIdentifier: bundleIdentifier,
+                    displayName: currentStat.displayName.isEmpty ? developmentStat.displayName : currentStat.displayName,
+                    totalWords: currentStat.totalWords + developmentStat.totalWords,
+                    totalCharacters: currentStat.totalCharacters + developmentStat.totalCharacters,
+                    sessionCount: currentStat.sessionCount + developmentStat.sessionCount,
+                    lastUsed: max(currentStat.lastUsed, developmentStat.lastUsed),
+                    iconData: currentStat.iconData ?? developmentStat.iconData,
+                    fallbackSymbolName: currentStat.fallbackSymbolName ?? developmentStat.fallbackSymbolName
+                )
+            } else {
+                mergedStats[bundleIdentifier] = developmentStat
+            }
+        }
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        if let data = try? encoder.encode(mergedStats) {
+            defaults.set(data, forKey: storageKey)
+            defaults.set(true, forKey: importDevelopmentKey)
         }
     }
     

--- a/Sources/Stores/UsageMetricsStore.swift
+++ b/Sources/Stores/UsageMetricsStore.swift
@@ -4,7 +4,7 @@ import Observation
 private enum UsageMetricsConstants {
     static let defaultTypingWordsPerMinute: Double = 45.0
     static let averageCharactersPerWord: Double = 5.0
-    static let maxDailyActivityDays: Int = 90 // Keep 90 days of daily activity
+    static let maxDailyActivityDays: Int = 3650 // Keep long-running local history.
 }
 
 internal struct UsageSnapshot: Equatable {
@@ -73,7 +73,10 @@ internal final class UsageMetricsStore {
         static let totalCharacters = "usage.totalCharacters"
         static let lastUpdated = "usage.lastUpdated"
         static let dailyActivity = "usage.dailyActivity"
+        static let didImportDevelopmentUsage = "usage.didImportDevelopmentUsage"
     }
+
+    private static let developmentBundleIdentifier = "com.audiowhisper-dev.app"
     
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -84,6 +87,7 @@ internal final class UsageMetricsStore {
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
+        Self.importDevelopmentUsageIfNeeded(defaults: defaults)
         let dailyData = defaults.dictionary(forKey: Keys.dailyActivity) as? [String: Int] ?? [:]
         self.snapshot = UsageSnapshot(
             totalSessions: defaults.integer(forKey: Keys.totalSessions),
@@ -228,6 +232,63 @@ internal final class UsageMetricsStore {
         defaults.set(snapshot.totalCharacters, forKey: Keys.totalCharacters)
         defaults.set(snapshot.lastUpdated, forKey: Keys.lastUpdated)
         defaults.set(snapshot.dailyActivity, forKey: Keys.dailyActivity)
+    }
+
+    private static func importDevelopmentUsageIfNeeded(defaults: UserDefaults) {
+        guard defaults === UserDefaults.standard else { return }
+        guard defaults.object(forKey: Keys.didImportDevelopmentUsage) == nil else { return }
+        guard let developmentDomain = defaults.persistentDomain(forName: developmentBundleIdentifier) else { return }
+
+        let developmentSessions = intValue(developmentDomain[Keys.totalSessions])
+        let developmentWords = intValue(developmentDomain[Keys.totalWords])
+        let developmentCharacters = intValue(developmentDomain[Keys.totalCharacters])
+        let developmentDuration = doubleValue(developmentDomain[Keys.totalDuration])
+        guard developmentSessions > 0 || developmentWords > 0 || developmentCharacters > 0 || developmentDuration > 0 else {
+            return
+        }
+
+        defaults.set(defaults.integer(forKey: Keys.totalSessions) + developmentSessions, forKey: Keys.totalSessions)
+        defaults.set(defaults.integer(forKey: Keys.totalWords) + developmentWords, forKey: Keys.totalWords)
+        defaults.set(defaults.integer(forKey: Keys.totalCharacters) + developmentCharacters, forKey: Keys.totalCharacters)
+        defaults.set(defaults.double(forKey: Keys.totalDuration) + developmentDuration, forKey: Keys.totalDuration)
+
+        let currentDaily = defaults.dictionary(forKey: Keys.dailyActivity) as? [String: Int] ?? [:]
+        let developmentDaily = intDictionary(developmentDomain[Keys.dailyActivity])
+        defaults.set(mergeDailyActivity(currentDaily, developmentDaily), forKey: Keys.dailyActivity)
+
+        let currentLastUpdated = defaults.object(forKey: Keys.lastUpdated) as? Date
+        let developmentLastUpdated = developmentDomain[Keys.lastUpdated] as? Date
+        defaults.set([currentLastUpdated, developmentLastUpdated].compactMap { $0 }.max(), forKey: Keys.lastUpdated)
+        defaults.set(true, forKey: Keys.didImportDevelopmentUsage)
+    }
+
+    private static func mergeDailyActivity(_ lhs: [String: Int], _ rhs: [String: Int]) -> [String: Int] {
+        var merged = lhs
+        for (day, count) in rhs {
+            merged[day, default: 0] += count
+        }
+        return merged
+    }
+
+    private static func intDictionary(_ value: Any?) -> [String: Int] {
+        guard let dictionary = value as? [String: Any] else { return [:] }
+        return dictionary.reduce(into: [:]) { result, entry in
+            result[entry.key] = intValue(entry.value)
+        }
+    }
+
+    private static func intValue(_ value: Any?) -> Int {
+        if let int = value as? Int { return int }
+        if let number = value as? NSNumber { return number.intValue }
+        if let string = value as? String { return Int(string) ?? 0 }
+        return 0
+    }
+
+    private static func doubleValue(_ value: Any?) -> Double {
+        if let double = value as? Double { return double }
+        if let number = value as? NSNumber { return number.doubleValue }
+        if let string = value as? String { return Double(string) ?? 0 }
+        return 0
     }
 
     static func estimatedWordCount(for text: String) -> Int {

--- a/Sources/Utilities/AppLanguage.swift
+++ b/Sources/Utilities/AppLanguage.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Combine
+
+/// Supported app languages
+internal enum AppLanguage: String, CaseIterable, Identifiable {
+    case english = "en"
+    case chinese = "zh"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .english: return "English"
+        case .chinese: return "中文"
+        }
+    }
+}
+
+/// Manages app language preference and notifies views of changes.
+internal final class LanguageManager: ObservableObject {
+    static let shared = LanguageManager()
+
+    private static let key = "appLanguage"
+
+    @Published var current: AppLanguage {
+        didSet {
+            UserDefaults.standard.set(current.rawValue, forKey: Self.key)
+        }
+    }
+
+    private init() {
+        let raw = UserDefaults.standard.string(forKey: Self.key) ?? ""
+        self.current = AppLanguage(rawValue: raw) ?? .english
+    }
+}

--- a/Sources/Utilities/L10n.swift
+++ b/Sources/Utilities/L10n.swift
@@ -1,0 +1,332 @@
+import Foundation
+
+/// Centralized bilingual strings. Access via `L10n.xxx`.
+/// All strings check `LanguageManager.shared.current` at call time.
+internal enum L10n {
+    private static var lang: AppLanguage { LanguageManager.shared.current }
+    private static var isCN: Bool { lang == .chinese }
+    static var isChinese: Bool { isCN }
+
+    // MARK: - Dashboard Nav
+    enum Nav {
+        static var overview: String { isCN ? "总览" : "Overview" }
+        static var timingAnalysis: String { isCN ? "耗时分析" : "Timing Analysis" }
+        static var transcripts: String { isCN ? "转录记录" : "Transcripts" }
+        static var categories: String { isCN ? "分类" : "Categories" }
+        static var recording: String { isCN ? "录音" : "Recording" }
+        static var providers: String { isCN ? "引擎" : "Providers" }
+        static var preferences: String { isCN ? "偏好设置" : "Preferences" }
+        static var permissions: String { isCN ? "权限" : "Permissions" }
+        static var selectSection: String { isCN ? "请在侧边栏选择一个功能" : "Select a section in the sidebar" }
+    }
+
+    // MARK: - Menu
+    enum Menu {
+        static var record: String { isCN ? "录音" : "Record" }
+        static var transcribeAudioFile: String { isCN ? "转录音频文件..." : "Transcribe Audio File..." }
+        static var dashboard: String { isCN ? "仪表盘..." : "Dashboard..." }
+        static var settings: String { isCN ? "偏好设置..." : "Settings..." }
+        static var help: String { isCN ? "帮助" : "Help" }
+        static var quit: String { isCN ? "退出" : "Quit" }
+        static var closeWindow: String { isCN ? "关闭窗口" : "Close Window" }
+        static var audioFilePanelMessage: String {
+            isCN ? "选择要转录的音频文件" : "Select an audio file to transcribe"
+        }
+        static var transcribePrompt: String { isCN ? "转录" : "Transcribe" }
+    }
+
+    // MARK: - Dashboard Home
+    enum Home {
+        static var thisMonth: String { isCN ? "本月统计" : "This Month" }
+        static var statsTitle: String { isCN ? "统计" : "Stats" }
+        static var statsSubtitle: String { isCN ? "全部本地使用记录的强度、效率和来源分布" : "Usage intensity, efficiency, and source breakdown across local usage." }
+        static var words: String { isCN ? "字数" : "Words" }
+        static var sessions: String { isCN ? "轮次" : "Sessions" }
+        static var providers: String { isCN ? "引擎" : "Providers" }
+        static var characters: String { isCN ? "字符" : "Characters" }
+        static var recordingDuration: String { isCN ? "录音时长" : "Recording Time" }
+        static var processingDuration: String { isCN ? "处理耗时" : "Processing Time" }
+        static var avgProcessing: String { isCN ? "平均处理" : "Avg. Processing" }
+        static var timeSaved: String { isCN ? "节省时间" : "Time Saved" }
+        static var avgWPM: String { isCN ? "平均语速 (WPM)" : "Avg. WPM" }
+        static var activeDays: String { isCN ? "活跃天数" : "Active Days" }
+        static var avgTranscriptionTime: String { isCN ? "平均转录耗时" : "Avg. Transcription Time" }
+        static var peakDay: String { isCN ? "峰值日" : "Peak Day" }
+        static var bestSingleDay: String { isCN ? "单日最高转录字数" : "Highest single-day word count" }
+        static var allSavedRecords: String { isCN ? "全部本地使用汇总" : "All local usage" }
+        static var basedOnTypingSpeed: String { isCN ? "按 45 WPM 打字速度估算" : "Estimated at 45 WPM typing" }
+        static var processingAverage: String { isCN ? "含语义纠正的平均处理时间" : "Average ASR + correction time" }
+        static var recordingBased: String { isCN ? "基于录音时长" : "Based on recording duration" }
+        static func activeDaysSummary(_ n: Int) -> String { isCN ? "\(n) 个活跃日" : "\(n) active day\(n == 1 ? "" : "s")" }
+        static var activity: String { isCN ? "活跃度" : "Activity" }
+        static var streak: String { isCN ? "连续天数" : "Streak" }
+        static func streakDays(_ n: Int) -> String { isCN ? "\(n) 天" : "\(n) day\(n == 1 ? "" : "s")" }
+        static var activityFooter: String { isCN ? "全部已保存记录的转录字数" : "Words transcribed across all saved records." }
+        static var calendarTitle: String { isCN ? "转录活动" : "Transcription Activity" }
+        static var calendarSubtitle: String { isCN ? "按天查看综合活跃度，点击日期查看完整指标" : "Daily combined activity. Click a date to inspect all metrics." }
+        static var calendarHint: String { isCN ? "旧版只有汇总，轮次和耗时按总量估算；长记录会横向滚动" : "Legacy rows use aggregate estimates for sessions and time. Long history scrolls horizontally." }
+        static var less: String { isCN ? "少" : "Less" }
+        static var more: String { isCN ? "多" : "More" }
+        static var dayOverview: String { isCN ? "当日概览" : "Day Overview" }
+        static var transcriptionTime: String { isCN ? "转录耗时" : "Transcription Time" }
+        static var transcriptionTimeFooter: String { isCN ? "最近 20 次转录的处理时间（含语义纠正）" : "Processing time for recent 20 transcriptions (incl. semantic correction)." }
+        static var topSources: String { isCN ? "常用来源" : "Top Sources" }
+        static var noSources: String { isCN ? "暂无来源数据" : "No sources yet." }
+        static var providerMix: String { isCN ? "引擎占比" : "Provider Mix" }
+        static var sourceMix: String { isCN ? "来源分布" : "Source Mix" }
+        static var modelBreakdown: String { isCN ? "模型" : "Models" }
+        static var dayBreakdown: String { isCN ? "当日构成" : "Day Breakdown" }
+        static var noDataForDay: String { isCN ? "这一天暂无保存的转录记录" : "No saved transcripts for this day." }
+        static var aggregateOnlyDay: String { isCN ? "这一天只有旧版汇总数据，没有逐条转录明细" : "Only legacy aggregate data is available for this day; individual transcripts were not saved." }
+        static var legacySummary: String { isCN ? "旧版汇总" : "Legacy Summary" }
+        static var noBreakdownData: String { isCN ? "暂无可拆分数据" : "No breakdown data yet." }
+        static var trendTitle: String { isCN ? "近期趋势" : "Recent Trend" }
+        static var trendSubtitle: String { isCN ? "最近 45 天的日级变化" : "Daily movement over the last 45 visible days" }
+        static var noTrendData: String { isCN ? "暂无趋势数据" : "No trend data yet." }
+        static var date: String { isCN ? "日期" : "Date" }
+        static var recentTranscripts: String { isCN ? "最近转录" : "Recent Transcripts" }
+        static var noTranscripts: String { isCN ? "暂无转录记录" : "No transcripts yet." }
+        static var viewAll: String { isCN ? "查看全部…" : "View All…" }
+        static func wordsSuffix(_ n: Int) -> String { isCN ? "\(n) 字" : "\(n) words" }
+        static func dayContext(sessions: Int, peakPercent: Double, weekPercent: Double) -> String {
+            if isCN {
+                return "\(sessions) 轮次  |  \(String(format: "%.0f", peakPercent))% 峰值日  |  \(String(format: "%.1f", weekPercent))% 本周字数"
+            }
+            return "\(sessions) session\(sessions == 1 ? "" : "s")  |  \(String(format: "%.0f", peakPercent))% of peak day  |  \(String(format: "%.1f", weekPercent))% of week"
+        }
+        static var seconds: String { isCN ? "秒" : "sec" }
+    }
+
+    // MARK: - Timing Analysis
+    enum Timing {
+        static var title: String { isCN ? "耗时分析" : "Timing Analysis" }
+        static var subtitle: String {
+            isCN ? "逐条拆分转录链路，定位录音、模型准备、ASR、语义纠正和粘贴中的主要耗时。" :
+                "Break down each transcription run across recording, model prep, ASR, correction, and paste."
+        }
+        static var includeRecording: String { isCN ? "包含录音时间" : "Include Recording Time" }
+        static var recordLimit: String { isCN ? "记录范围" : "Record Range" }
+        static func latestRecords(_ count: Int) -> String { isCN ? "最近 \(count) 次" : "Latest \(count)" }
+        static var allRecords: String { isCN ? "全部" : "All" }
+        static var noTimingData: String { isCN ? "暂无可分析的耗时数据" : "No timing data yet." }
+        static var noTimingDataHint: String {
+            isCN ? "旧记录可能只有总耗时。完成新的转录后，这里会开始显示分阶段拆分。" :
+                "Older records may only have total processing time. New runs will include stage breakdowns."
+        }
+        static var runBreakdown: String { isCN ? "单次耗时拆分" : "Run Breakdown" }
+        static var slowestStage: String { isCN ? "主要瓶颈" : "Main Bottleneck" }
+        static var slowestRun: String { isCN ? "最慢单次" : "Slowest Run" }
+        static var averageProcessing: String { isCN ? "平均处理" : "Avg. Processing" }
+        static var analyzedRuns: String { isCN ? "分析记录" : "Runs" }
+        static var stageDistribution: String { isCN ? "阶段占比" : "Stage Distribution" }
+        static var recordDetails: String { isCN ? "记录明细" : "Record Details" }
+        static var legacyProcessing: String { isCN ? "处理总耗时（旧记录）" : "Processing Total (Legacy)" }
+        static var untrackedProcessing: String { isCN ? "未拆分处理" : "Untracked Processing" }
+        static var modelReady: String { isCN ? "模型准备" : "Model Prep" }
+        static var asr: String { isCN ? "ASR 转录" : "ASR" }
+        static var correction: String { isCN ? "语义纠正" : "Correction" }
+        static var clipboard: String { isCN ? "写剪贴板" : "Clipboard" }
+        static var paste: String { isCN ? "粘贴/切回应用" : "Paste" }
+        static var recording: String { isCN ? "录音" : "Recording" }
+        static var total: String { isCN ? "总计" : "Total" }
+        static var provider: String { isCN ? "引擎" : "Provider" }
+        static var source: String { isCN ? "来源" : "Source" }
+        static var words: String { isCN ? "字数" : "Words" }
+        static var oldRecordHint: String { isCN ? "旧记录没有阶段字段" : "Legacy record without stage fields" }
+    }
+
+    // MARK: - Weekdays
+    enum Weekday {
+        static var short: [String] { isCN ? ["日", "一", "二", "三", "四", "五", "六"] : ["S", "M", "T", "W", "T", "F", "S"] }
+    }
+
+    // MARK: - Recording
+    enum Recording {
+        static var preparingAudio: String { isCN ? "准备音频..." : "Preparing audio..." }
+        static var semanticCorrection: String { isCN ? "语义纠正中..." : "Semantic correction..." }
+        static var transcribingFile: String { isCN ? "正在转录文件..." : "Transcribing file..." }
+        static var retrying: String { isCN ? "重新转录中..." : "Retrying transcription..." }
+    }
+
+    // MARK: - Providers
+    enum Provider {
+        static func displayName(for provider: String) -> String {
+            switch provider.lowercased() {
+            case "openai": return "OpenAI"
+            case "gemini": return "Gemini"
+            case "local": return isCN ? "本地 Whisper" : "Local Whisper"
+            case "parakeet": return "Parakeet"
+            case "funasr": return "FunASR"
+            default: return provider.capitalized
+            }
+        }
+    }
+
+    // MARK: - Categories
+    enum Categories {
+        static var categoryTypes: String { isCN ? "分类类型" : "Category Types" }
+        static var appAssignments: String { isCN ? "应用分配" : "App Assignments" }
+        static var assignmentsFooter: String {
+            isCN ? "粘贴完成的转录文本时，会自动使用对应应用的分类设置。" : "Assignments are applied automatically when you paste a finished transcript."
+        }
+        static var noAppsRecorded: String { isCN ? "还没有记录到应用来源。" : "No apps recorded yet." }
+        static var systemBadge: String { isCN ? "系统" : "System" }
+        static var newCategory: String { isCN ? "新建分类…" : "New Category…" }
+        static var resetToDefaults: String { isCN ? "恢复默认" : "Reset to Defaults" }
+        static var resetToDefault: String { isCN ? "恢复默认" : "Reset to Default" }
+        static func editCategory(_ name: String) -> String {
+            isCN ? "编辑 \(name)" : "Edit \(name)"
+        }
+
+        static var newCategoryTitle: String { isCN ? "新建分类" : "New Category" }
+        static var editCategoryTitle: String { isCN ? "编辑分类" : "Edit Category" }
+        static var categoryNamePlaceholder: String { isCN ? "分类名称" : "Category Name" }
+        static var identifierPlaceholder: String { isCN ? "标识符" : "identifier" }
+        static var identity: String { isCN ? "身份信息" : "Identity" }
+        static var displayName: String { isCN ? "显示名称" : "Display Name" }
+        static var identifier: String { isCN ? "标识符" : "Identifier" }
+        static var systemIdentifierHelp: String { isCN ? "系统分类的标识符不能修改。" : "System category identifiers can’t be changed." }
+        static var appearance: String { isCN ? "外观" : "Appearance" }
+        static var icon: String { isCN ? "图标（SF Symbol）" : "Icon (SF Symbol)" }
+        static var color: String { isCN ? "颜色" : "Color" }
+        static var correction: String { isCN ? "纠正设置" : "Correction" }
+        static var description: String { isCN ? "说明" : "Description" }
+        static var promptTemplate: String { isCN ? "提示词模板" : "Prompt Template" }
+        static var promptTemplateHelp: String {
+            isCN ? "发送给纠正模型的该分类专用指令。" : "Instructions sent to the correction model for this category."
+        }
+        static var deleteCategory: String { isCN ? "删除分类" : "Delete Category" }
+        static var newCategoryDefaultName: String { isCN ? "新分类" : "New Category" }
+        static var categoryPurposePlaceholder: String { isCN ? "描述这个分类的用途" : "Describe this category's purpose" }
+        static var displayNameRequired: String { isCN ? "显示名称不能为空。" : "Display name is required." }
+        static var duplicateIdentifier: String { isCN ? "已有分类使用这个标识符。" : "A category with this identifier already exists." }
+
+        static func name(for id: String, fallback: String) -> String {
+            switch id {
+            case "terminal": return isCN ? "终端" : "Terminal"
+            case "coding": return isCN ? "编程" : "Coding"
+            case "chat": return isCN ? "聊天" : "Chat"
+            case "writing": return isCN ? "写作" : "Writing"
+            case "email": return isCN ? "邮件" : "Email"
+            case "general": return isCN ? "通用" : "General"
+            default: return fallback
+            }
+        }
+
+        static func promptDescription(for id: String, fallback: String) -> String {
+            switch id {
+            case "terminal":
+                return isCN
+                    ? "保留 CLI、GitHub、repo、部署、监控术语、参数和路径"
+                    : "Preserves CLI, GitHub, repo, deploy, monitoring terms, flags, and paths"
+            case "coding":
+                return isCN
+                    ? "保留代码、GitHub、repo、PR、campaign 和监控相关词汇"
+                    : "Preserves code, GitHub, repo, PR, campaign, and monitoring vocabulary"
+            case "chat":
+                return isCN
+                    ? "轻量纠错，保留聊天语气和中英文混合技术词"
+                    : "Light corrections, keeps casual tone and mixed Chinese/English tech terms"
+            case "writing":
+                return isCN
+                    ? "更彻底的语法整理，适合正式写作。修正句子片段和同音误识别"
+                    : "Thorough grammar, formal style. Fixes fragments and homophones"
+            case "email":
+                return isCN
+                    ? "专业邮件语气，保留问候语和落款。修正常见误识别：'attach meant' → 'attachment'"
+                    : "Professional tone, preserves greetings/sign-offs. Fixes: 'attach meant' → 'attachment'"
+            case "general":
+                return isCN
+                    ? "均衡清理，根据上下文修正常见技术词误识别"
+                    : "Balanced cleanup, adapts to context, fixes common tech-term misrecognitions"
+            default:
+                return fallback
+            }
+        }
+    }
+
+    // MARK: - Duration formatting
+    enum Format {
+        static func duration(_ interval: TimeInterval) -> String {
+            guard interval > 0 else { return isCN ? "0 分钟" : "0m" }
+            let totalSeconds = Int(interval)
+            let hours = totalSeconds / 3600
+            let minutes = (totalSeconds % 3600) / 60
+            if isCN {
+                return hours > 0 ? "\(hours) 小时 \(minutes) 分钟" : "\(minutes) 分钟"
+            } else {
+                return hours > 0 ? "\(hours)h \(minutes)m" : "\(minutes)m"
+            }
+        }
+    }
+
+    // MARK: - Record Row
+    enum RecordRow {
+        static var copyToClipboard: String { isCN ? "复制到剪贴板" : "Copy to clipboard" }
+        static var delete: String { isCN ? "删除" : "Delete" }
+        static func accessibilityLabel(date: String, provider: String) -> String {
+            isCN ? "转录于 \(date)，使用 \(provider)" : "Transcription from \(date), using \(provider)"
+        }
+        static var accessibilityHint: String {
+            isCN ? "点击展开或收起，使用操作按钮复制或删除" : "Tap to expand or collapse. Use action buttons to copy or delete."
+        }
+    }
+
+    // MARK: - Preferences
+    enum Preferences {
+        static var language: String { isCN ? "语言" : "Language" }
+        static var languageFooter: String { isCN ? "更改界面显示语言" : "Change the display language of the interface." }
+        static var general: String { isCN ? "通用" : "General" }
+        static var startAtLogin: String { isCN ? "开机启动" : "Start at Login" }
+        static var startAtLoginDesc: String { isCN ? "登录时自动启动 AudioWhisper" : "Launch AudioWhisper when you sign in." }
+        static var expressMode: String { isCN ? "快捷模式" : "Express Mode" }
+        static var expressModeDesc: String { isCN ? "快捷键直接开始/停止录音" : "Hotkey immediately starts and stops recording." }
+        static var autoBoost: String { isCN ? "自动增强麦克风" : "Auto-Boost Microphone" }
+        static var autoBoostDesc: String { isCN ? "录音时暂时最大化麦克风输入" : "Temporarily maximize mic input while recording." }
+        static var smartPaste: String { isCN ? "智能粘贴" : "Smart Paste" }
+        static var smartPasteDesc: String { isCN ? "自动粘贴完成的转录文本" : "Automatically paste finished transcripts." }
+        static var completionSound: String { isCN ? "完成提示音" : "Completion Sound" }
+        static var completionSoundDesc: String { isCN ? "转录完成时播放提示音" : "Play a chime when transcription finishes." }
+        static var history: String { isCN ? "历史记录" : "History" }
+        static var saveHistory: String { isCN ? "保存转录历史" : "Save Transcription History" }
+        static var saveHistoryDesc: String { isCN ? "将转录记录保存到本地，方便搜索和回顾" : "Store transcripts locally so you can search and review them later." }
+        static var storage: String { isCN ? "存储" : "Storage" }
+        static var maxModelStorage: String { isCN ? "最大模型存储" : "Max Model Storage" }
+        static var about: String { isCN ? "关于" : "About" }
+        static var version: String { isCN ? "版本" : "Version" }
+    }
+
+    // MARK: - Permissions
+    enum Permissions {
+        static var microphone: String { isCN ? "麦克风" : "Microphone" }
+        static var accessibility: String { isCN ? "辅助功能" : "Accessibility" }
+        static var status: String { isCN ? "状态" : "Status" }
+        static var granted: String { isCN ? "已授权" : "Granted" }
+        static var denied: String { isCN ? "未授权" : "Denied" }
+        static var required: String { isCN ? "需要授权" : "Required" }
+        static var requestAccess: String { isCN ? "请求权限" : "Request Access" }
+        static var openSettings: String { isCN ? "打开设置" : "Open Settings" }
+        static var refresh: String { isCN ? "刷新" : "Refresh" }
+        static var micDesc: String { isCN ? "AudioWhisper 需要麦克风权限来录制音频进行转录。" : "AudioWhisper needs microphone access to record audio for transcription." }
+        static var a11yDesc: String { isCN ? "智能粘贴需要辅助功能权限才能在其他应用中输入文本。" : "Accessibility permission is required for Smart Paste to type into other apps." }
+    }
+
+    // MARK: - Common
+    enum Common {
+        static var cancel: String { isCN ? "取消" : "Cancel" }
+        static var save: String { isCN ? "保存" : "Save" }
+        static var add: String { isCN ? "添加" : "Add" }
+        static var done: String { isCN ? "完成" : "Done" }
+        static var reset: String { isCN ? "重置" : "Reset" }
+        static var install: String { isCN ? "安装" : "Install" }
+        static var installed: String { isCN ? "已安装" : "Installed" }
+        static var ready: String { isCN ? "就绪" : "Ready" }
+        static var setupRequired: String { isCN ? "需要配置" : "Setup required" }
+        static var downloaded: String { isCN ? "已下载" : "Downloaded" }
+        static var notDownloaded: String { isCN ? "未下载" : "Not downloaded" }
+        static var recommended: String { isCN ? "推荐" : "RECOMMENDED" }
+        static var environment: String { isCN ? "环境" : "Environment" }
+        static var model: String { isCN ? "模型" : "Model" }
+        static var advanced: String { isCN ? "高级" : "Advanced" }
+    }
+}

--- a/Sources/Utilities/L10n.swift
+++ b/Sources/Utilities/L10n.swift
@@ -24,9 +24,7 @@ internal enum L10n {
     enum Menu {
         static var record: String { isCN ? "录音" : "Record" }
         static var transcribeAudioFile: String { isCN ? "转录音频文件..." : "Transcribe Audio File..." }
-        static var dashboard: String { isCN ? "仪表盘..." : "Dashboard..." }
-        static var settings: String { isCN ? "偏好设置..." : "Settings..." }
-        static var help: String { isCN ? "帮助" : "Help" }
+        static var settings: String { isCN ? "设置" : "Settings" }
         static var quit: String { isCN ? "退出" : "Quit" }
         static var closeWindow: String { isCN ? "关闭窗口" : "Close Window" }
         static var audioFilePanelMessage: String {

--- a/Sources/Utilities/LocalizedStrings.swift
+++ b/Sources/Utilities/LocalizedStrings.swift
@@ -121,8 +121,8 @@ internal enum LocalizedStrings {
             value: "Record", 
             comment: "Menu item to start recording")
         
-        static let settings = NSLocalizedString("menu.settings", 
-            value: "Settings...", 
+        static let settings = NSLocalizedString("menu.settings",
+            value: "Settings",
             comment: "Menu item to open settings")
         
         static let quit = NSLocalizedString("menu.quit", 

--- a/Sources/Views/ContentView+Paste.swift
+++ b/Sources/Views/ContentView+Paste.swift
@@ -20,8 +20,9 @@ private final class ObserverBox: @unchecked Sendable {
 }
 
 internal extension ContentView {
-    func performUserTriggeredPaste() {
+    func performUserTriggeredPaste(recordID: UUID? = nil, processStart: Date? = nil, pasteStart: Date? = nil) {
         guard let targetApp = findValidTargetApp() else {
+            updateTimingAfterPaste(recordID: recordID, processStart: processStart, pasteStart: pasteStart)
             showSuccess = false
             hideRecordingWindow()
             return
@@ -29,7 +30,12 @@ internal extension ContentView {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             self.hideRecordingWindow()
-            self.activateTargetAppAndPaste(targetApp)
+            self.activateTargetAppAndPaste(
+                targetApp,
+                recordID: recordID,
+                processStart: processStart,
+                pasteStart: pasteStart
+            )
         }
     }
     
@@ -73,15 +79,37 @@ internal extension ContentView {
         }
     }
     
-    func activateTargetAppAndPaste(_ target: NSRunningApplication) {
+    func activateTargetAppAndPaste(
+        _ target: NSRunningApplication,
+        recordID: UUID? = nil,
+        processStart: Date? = nil,
+        pasteStart: Date? = nil
+    ) {
         Task { @MainActor in
             do {
                 try await activateApplication(target)
                 await pasteManager.pasteWithCompletionHandler()
+                updateTimingAfterPaste(recordID: recordID, processStart: processStart, pasteStart: pasteStart)
                 self.showSuccess = false
             } catch {
+                updateTimingAfterPaste(recordID: recordID, processStart: processStart, pasteStart: pasteStart)
                 self.showSuccess = false
             }
+        }
+    }
+
+    func updateTimingAfterPaste(recordID: UUID?, processStart: Date?, pasteStart: Date?) {
+        guard let recordID else { return }
+        let now = Date()
+        let pasteTime = pasteStart.map { max(0, now.timeIntervalSince($0)) }
+        let endToEndTime = processStart.map { max(0, now.timeIntervalSince($0)) }
+
+        Task {
+            try? await DataManager.shared.updateTiming(
+                for: recordID,
+                pasteTime: pasteTime,
+                endToEndTime: endToEndTime
+            )
         }
     }
 

--- a/Sources/Views/ContentView+Recording.swift
+++ b/Sources/Views/ContentView+Recording.swift
@@ -31,9 +31,10 @@ internal extension ContentView {
         if shouldHintThisRun { showFirstModelUseHint = true }
 
         processingTask = Task {
+            let processStart = Date()
             isProcessing = true
             transcriptionStartTime = Date()
-            progressMessage = "Preparing audio..."
+            progressMessage = L10n.Recording.preparingAudio
             
             do {
                 try Task.checkCancellation()
@@ -49,12 +50,23 @@ internal extension ContentView {
                 lastAudioURL = audioURL
                 try Task.checkCancellation()
                 
+                var modelReadyTime: TimeInterval?
+                var asrTime: TimeInterval = 0
+                var correctionTime: TimeInterval = 0
+                var clipboardTime: TimeInterval = 0
+                let transcriptionStart = Date()
                 let text: String
                 if transcriptionProvider == .local {
+                    let modelReadyStart = Date()
                     try await ensureWhisperModelIsReadyForTranscription(selectedWhisperModel)
+                    modelReadyTime = Date().timeIntervalSince(modelReadyStart)
+                    let asrStart = Date()
                     text = try await speechService.transcribeRaw(audioURL: audioURL, provider: transcriptionProvider, model: selectedWhisperModel)
+                    asrTime = Date().timeIntervalSince(asrStart)
                 } else {
+                    let asrStart = Date()
                     text = try await speechService.transcribeRaw(audioURL: audioURL, provider: transcriptionProvider)
+                    asrTime = Date().timeIntervalSince(asrStart)
                 }
                 
                 try Task.checkCancellation()
@@ -64,8 +76,10 @@ internal extension ContentView {
                 var finalText = text
                 let sourceBundleId: String? = await MainActor.run { currentSourceAppInfo().bundleIdentifier }
                 if mode != .off {
-                    await MainActor.run { progressMessage = "Semantic correction..." }
+                    await MainActor.run { progressMessage = L10n.Recording.semanticCorrection }
+                    let correctionStart = Date()
                     let outcome = await semanticCorrectionService.correctWithWarning(text: text, providerUsed: transcriptionProvider, sourceAppBundleId: sourceBundleId)
+                    correctionTime = Date().timeIntervalSince(correctionStart)
                     if let warning = outcome.warning {
                         await MainActor.run { progressMessage = warning }
                     }
@@ -74,12 +88,16 @@ internal extension ContentView {
                         finalText = outcome.text
                     }
                 }
+                let transcriptionElapsed = Date().timeIntervalSince(transcriptionStart)
                 let wordCount = UsageMetricsStore.estimatedWordCount(for: finalText)
                 let characterCount = finalText.count
 
+                let clipboardStart = Date()
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(finalText, forType: .string)
+                clipboardTime = Date().timeIntervalSince(clipboardStart)
                 let shouldSave: Bool = await MainActor.run { DataManager.shared.isHistoryEnabled }
+                var savedRecordID: UUID?
                 if shouldSave {
                     let modelUsed: String? = await MainActor.run { (transcriptionProvider == .local) ? self.selectedWhisperModel.rawValue : nil }
                     let sourceInfo: SourceAppInfo = await MainActor.run { currentSourceAppInfo() }
@@ -92,8 +110,15 @@ internal extension ContentView {
                         characterCount: characterCount,
                         sourceAppBundleId: sourceInfo.bundleIdentifier,
                         sourceAppName: sourceInfo.displayName,
-                        sourceAppIconData: sourceInfo.iconData
+                        sourceAppIconData: sourceInfo.iconData,
+                        transcriptionTime: transcriptionElapsed,
+                        modelReadyTime: modelReadyTime,
+                        asrTime: asrTime,
+                        correctionTime: correctionTime,
+                        clipboardTime: clipboardTime,
+                        endToEndTime: Date().timeIntervalSince(processStart)
                     )
+                    savedRecordID = record.id
                     await DataManager.shared.saveTranscriptionQuietly(record)
                 }
                 await MainActor.run {
@@ -104,7 +129,7 @@ internal extension ContentView {
                     )
                     recordSourceUsage(words: wordCount, characters: characterCount)
                     transcriptionStartTime = nil
-                    showConfirmationAndPaste(text: finalText)
+                    showConfirmationAndPaste(text: finalText, recordID: savedRecordID, processStart: processStart)
                     if shouldHintThisRun { hasShownFirstModelUseHint = true; showFirstModelUseHint = false }
                 }
             } catch is CancellationError {
@@ -154,21 +179,33 @@ internal extension ContentView {
         if shouldHintThisRun { showFirstModelUseHint = true }
 
         processingTask = Task {
+            let processStart = Date()
             isProcessing = true
             transcriptionStartTime = Date()
-            progressMessage = "Transcribing file..."
+            progressMessage = L10n.Recording.transcribingFile
 
             do {
                 try Task.checkCancellation()
                 lastAudioURL = audioURL
                 try Task.checkCancellation()
 
+                var modelReadyTime: TimeInterval?
+                var asrTime: TimeInterval = 0
+                var correctionTime: TimeInterval = 0
+                var clipboardTime: TimeInterval = 0
+                let transcriptionStart = Date()
                 let text: String
                 if transcriptionProvider == .local {
+                    let modelReadyStart = Date()
                     try await ensureWhisperModelIsReadyForTranscription(selectedWhisperModel)
+                    modelReadyTime = Date().timeIntervalSince(modelReadyStart)
+                    let asrStart = Date()
                     text = try await speechService.transcribeRaw(audioURL: audioURL, provider: transcriptionProvider, model: selectedWhisperModel)
+                    asrTime = Date().timeIntervalSince(asrStart)
                 } else {
+                    let asrStart = Date()
                     text = try await speechService.transcribeRaw(audioURL: audioURL, provider: transcriptionProvider)
+                    asrTime = Date().timeIntervalSince(asrStart)
                 }
 
                 try Task.checkCancellation()
@@ -178,8 +215,10 @@ internal extension ContentView {
                 var finalText = text
                 let sourceBundleId: String? = await MainActor.run { currentSourceAppInfo().bundleIdentifier }
                 if mode != .off {
-                    await MainActor.run { progressMessage = "Semantic correction..." }
+                    await MainActor.run { progressMessage = L10n.Recording.semanticCorrection }
+                    let correctionStart = Date()
                     let outcome = await semanticCorrectionService.correctWithWarning(text: text, providerUsed: transcriptionProvider, sourceAppBundleId: sourceBundleId)
+                    correctionTime = Date().timeIntervalSince(correctionStart)
                     if let warning = outcome.warning {
                         await MainActor.run { progressMessage = warning }
                     }
@@ -188,6 +227,7 @@ internal extension ContentView {
                         finalText = outcome.text
                     }
                 }
+                let transcriptionElapsed = Date().timeIntervalSince(transcriptionStart)
                 let wordCount = UsageMetricsStore.estimatedWordCount(for: finalText)
                 let characterCount = finalText.count
 
@@ -195,9 +235,12 @@ internal extension ContentView {
                 let fileSize = (fileAttributes?[.size] as? Int64) ?? 0
                 let estimatedDuration = TimeInterval(fileSize) / 16000.0
 
+                let clipboardStart = Date()
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(finalText, forType: .string)
+                clipboardTime = Date().timeIntervalSince(clipboardStart)
                 let shouldSave: Bool = await MainActor.run { DataManager.shared.isHistoryEnabled }
+                var savedRecordID: UUID?
                 if shouldSave {
                     let modelUsed: String? = await MainActor.run { (transcriptionProvider == .local) ? self.selectedWhisperModel.rawValue : nil }
                     let sourceInfo: SourceAppInfo = await MainActor.run { currentSourceAppInfo() }
@@ -210,8 +253,15 @@ internal extension ContentView {
                         characterCount: characterCount,
                         sourceAppBundleId: sourceInfo.bundleIdentifier,
                         sourceAppName: sourceInfo.displayName,
-                        sourceAppIconData: sourceInfo.iconData
+                        sourceAppIconData: sourceInfo.iconData,
+                        transcriptionTime: transcriptionElapsed,
+                        modelReadyTime: modelReadyTime,
+                        asrTime: asrTime,
+                        correctionTime: correctionTime,
+                        clipboardTime: clipboardTime,
+                        endToEndTime: Date().timeIntervalSince(processStart)
                     )
+                    savedRecordID = record.id
                     await DataManager.shared.saveTranscriptionQuietly(record)
                 }
                 await MainActor.run {
@@ -222,7 +272,7 @@ internal extension ContentView {
                     )
                     recordSourceUsage(words: wordCount, characters: characterCount)
                     transcriptionStartTime = nil
-                    showConfirmationAndPaste(text: finalText)
+                    showConfirmationAndPaste(text: finalText, recordID: savedRecordID, processStart: processStart)
                     if shouldHintThisRun { hasShownFirstModelUseHint = true; showFirstModelUseHint = false }
                 }
             } catch is CancellationError {
@@ -265,7 +315,7 @@ internal extension ContentView {
         }
     }
 
-    func showConfirmationAndPaste(text: String) {
+    func showConfirmationAndPaste(text: String, recordID: UUID? = nil, processStart: Date? = nil) {
         showSuccess = true
         isProcessing = false
         soundManager.playCompletionSound()
@@ -274,10 +324,11 @@ internal extension ContentView {
         if enableSmartPaste {
             if !awaitingSemanticPaste {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    performUserTriggeredPaste()
+                    performUserTriggeredPaste(recordID: recordID, processStart: processStart, pasteStart: Date())
                 }
             }
         } else {
+            updateTimingAfterPaste(recordID: recordID, processStart: processStart, pasteStart: nil)
             NotificationCenter.default.post(name: .restoreFocusToPreviousApp, object: nil)
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {

--- a/Sources/Views/Dashboard/CategoryEditorSheet.swift
+++ b/Sources/Views/Dashboard/CategoryEditorSheet.swift
@@ -34,19 +34,19 @@ internal struct CategoryEditorSheet: View {
 
         let cat = category ?? CategoryDefinition(
             id: "new-category",
-            displayName: "New Category",
+            displayName: L10n.Categories.newCategoryDefaultName,
             icon: "sparkles",
             colorHex: "#888888",
-            promptDescription: "Describe this category's purpose",
+            promptDescription: L10n.Categories.categoryPurposePlaceholder,
             promptTemplate: CategoryDefinition.fallback.promptTemplate,
             isSystem: false
         )
 
-        _displayName = State(initialValue: cat.displayName)
+        _displayName = State(initialValue: cat.localizedDisplayName)
         _identifier = State(initialValue: cat.id)
         _icon = State(initialValue: cat.icon)
         _accentColor = State(initialValue: cat.color)
-        _promptDescription = State(initialValue: cat.promptDescription)
+        _promptDescription = State(initialValue: cat.localizedPromptDescription)
         _promptTemplate = State(initialValue: cat.promptTemplate)
     }
 
@@ -61,11 +61,11 @@ internal struct CategoryEditorSheet: View {
                         .background(accentColor, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
 
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(displayName.isEmpty ? "Category Name" : displayName)
+                        Text(displayName.isEmpty ? L10n.Categories.categoryNamePlaceholder : displayName)
                             .font(.headline)
                             .lineLimit(1)
 
-                        Text(identifier.isEmpty ? "identifier" : identifier)
+                        Text(identifier.isEmpty ? L10n.Categories.identifierPlaceholder : identifier)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
@@ -75,7 +75,7 @@ internal struct CategoryEditorSheet: View {
                     Spacer(minLength: 0)
 
                     if isSystem {
-                        Text("System")
+                        Text(L10n.Categories.systemBadge)
                             .font(.caption2.weight(.semibold))
                             .foregroundStyle(.secondary)
                     }
@@ -83,31 +83,31 @@ internal struct CategoryEditorSheet: View {
                 .padding(.vertical, 4)
             }
 
-            Section("Identity") {
-                TextField("Display Name", text: $displayName)
+            Section(L10n.Categories.identity) {
+                TextField(L10n.Categories.displayName, text: $displayName)
 
-                TextField("Identifier", text: $identifier)
+                TextField(L10n.Categories.identifier, text: $identifier)
                     .disabled(isSystem)
 
                 if isSystem {
-                    Text("System category identifiers can’t be changed.")
+                    Text(L10n.Categories.systemIdentifierHelp)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
             }
 
-            Section("Appearance") {
-                TextField("Icon (SF Symbol)", text: $icon)
+            Section(L10n.Categories.appearance) {
+                TextField(L10n.Categories.icon, text: $icon)
 
-                ColorPicker("Color", selection: $accentColor, supportsOpacity: false)
+                ColorPicker(L10n.Categories.color, selection: $accentColor, supportsOpacity: false)
             }
 
-            Section("Correction") {
-                TextField("Description", text: $promptDescription, axis: .vertical)
+            Section(L10n.Categories.correction) {
+                TextField(L10n.Categories.description, text: $promptDescription, axis: .vertical)
                     .lineLimit(2...3)
 
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("Prompt Template")
+                    Text(L10n.Categories.promptTemplate)
                         .font(.subheadline.weight(.semibold))
 
                     TextEditor(text: $promptTemplate)
@@ -118,7 +118,7 @@ internal struct CategoryEditorSheet: View {
                                 .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
                         )
 
-                    Text("Instructions sent to the correction model for this category.")
+                    Text(L10n.Categories.promptTemplateHelp)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -134,7 +134,7 @@ internal struct CategoryEditorSheet: View {
 
             if !isNewCategory && !isSystem, let onDelete {
                 Section {
-                    Button("Delete Category", role: .destructive) {
+                    Button(L10n.Categories.deleteCategory, role: .destructive) {
                         onDelete()
                         dismiss()
                     }
@@ -142,17 +142,17 @@ internal struct CategoryEditorSheet: View {
             }
         }
         .formStyle(.grouped)
-        .navigationTitle(isNewCategory ? "New Category" : "Edit Category")
+        .navigationTitle(isNewCategory ? L10n.Categories.newCategoryTitle : L10n.Categories.editCategoryTitle)
         .frame(width: 560, height: 680)
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                Button("Cancel", role: .cancel) {
+                Button(L10n.Common.cancel, role: .cancel) {
                     dismiss()
                 }
             }
 
             ToolbarItem(placement: .confirmationAction) {
-                Button(isNewCategory ? "Add" : "Save") {
+                Button(isNewCategory ? L10n.Common.add : L10n.Common.save) {
                     save()
                 }
                 .disabled(displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
@@ -167,14 +167,14 @@ internal struct CategoryEditorSheet: View {
         let trimmedName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if trimmedName.isEmpty {
-            validationError = "Display name is required."
+            validationError = L10n.Categories.displayNameRequired
             return
         }
 
         // Check for duplicate ID (only if ID changed or new category).
         let originalId = originalCategory?.id
         if trimmedId != originalId && categoryStore.containsCategory(withId: trimmedId) {
-            validationError = "A category with this identifier already exists."
+            validationError = L10n.Categories.duplicateIdentifier
             return
         }
 

--- a/Sources/Views/Dashboard/DashboardCategoriesView.swift
+++ b/Sources/Views/Dashboard/DashboardCategoriesView.swift
@@ -15,7 +15,7 @@ internal struct DashboardCategoriesView: View {
 
     var body: some View {
         Form {
-            Section("Category Types") {
+            Section(L10n.Categories.categoryTypes) {
                 ForEach(categoryStore.categories, id: \.id) { category in
                     Button {
                         editingCategory = category
@@ -27,18 +27,18 @@ internal struct DashboardCategoriesView: View {
 
                             VStack(alignment: .leading, spacing: 2) {
                                 HStack(spacing: 8) {
-                                    Text(category.displayName)
+                                    Text(category.localizedDisplayName)
                                         .font(.body.weight(.medium))
                                         .foregroundStyle(.primary)
 
                                     if category.isSystem {
-                                        Text("System")
+                                        Text(L10n.Categories.systemBadge)
                                             .font(.caption2.weight(.semibold))
                                             .foregroundStyle(.secondary)
                                     }
                                 }
 
-                                Text(category.promptDescription)
+                                Text(category.localizedPromptDescription)
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                                     .lineLimit(1)
@@ -53,19 +53,19 @@ internal struct DashboardCategoriesView: View {
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
-                    .help("Edit \(category.displayName)")
+                    .help(L10n.Categories.editCategory(category.localizedDisplayName))
                 }
 
                 HStack(spacing: 10) {
                     Button {
                         isCreatingNew = true
                     } label: {
-                        Label("New Category…", systemImage: "plus")
+                        Label(L10n.Categories.newCategory, systemImage: "plus")
                     }
 
                     Spacer()
 
-                    Button("Reset to Defaults") {
+                    Button(L10n.Categories.resetToDefaults) {
                         categoryStore.resetToDefaults()
                     }
                 }
@@ -73,7 +73,7 @@ internal struct DashboardCategoriesView: View {
 
             Section {
                 if topSources.isEmpty {
-                    Text("No apps recorded yet.")
+                    Text(L10n.Categories.noAppsRecorded)
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(topSources) { source in
@@ -81,14 +81,14 @@ internal struct DashboardCategoriesView: View {
                             HStack(spacing: 8) {
                                 Picker("", selection: categoryBinding(for: source.bundleIdentifier)) {
                                     ForEach(categoryStore.categories, id: \.id) { category in
-                                        Text(category.displayName).tag(category.id)
+                                        Text(category.localizedDisplayName).tag(category.id)
                                     }
                                 }
                                 .labelsHidden()
                                 .pickerStyle(.menu)
 
                                 if categoryManager.isUserOverridden(source.bundleIdentifier) {
-                                    Button("Reset") {
+                                    Button(L10n.Common.reset) {
                                         categoryManager.resetToDefault(for: source.bundleIdentifier)
                                     }
                                     .controlSize(.small)
@@ -99,7 +99,7 @@ internal struct DashboardCategoriesView: View {
                         }
                         .contextMenu {
                             if categoryManager.isUserOverridden(source.bundleIdentifier) {
-                                Button("Reset to Default") {
+                                Button(L10n.Categories.resetToDefault) {
                                     categoryManager.resetToDefault(for: source.bundleIdentifier)
                                 }
                             }
@@ -107,9 +107,9 @@ internal struct DashboardCategoriesView: View {
                     }
                 }
             } header: {
-                Text("App Assignments")
+                Text(L10n.Categories.appAssignments)
             } footer: {
-                Text("Assignments are applied automatically when you paste a finished transcript.")
+                Text(L10n.Categories.assignmentsFooter)
             }
         }
         .formStyle(.grouped)

--- a/Sources/Views/Dashboard/DashboardHomeView.swift
+++ b/Sources/Views/Dashboard/DashboardHomeView.swift
@@ -1,227 +1,1380 @@
 import SwiftUI
 import SwiftData
+import Charts
 import AppKit
 
+private struct BreakdownRow: Identifiable, Equatable {
+    let label: String
+    let words: Int
+    let characters: Int
+    let sessions: Int
+    let recordingDuration: TimeInterval
+    let processingDuration: TimeInterval
+    let processingSamples: Int
+
+    var id: String { label }
+
+    var averageProcessingTime: TimeInterval {
+        guard processingSamples > 0 else { return 0 }
+        return processingDuration / Double(processingSamples)
+    }
+}
+
+private struct DailyTranscriptionSummary: Identifiable, Equatable {
+    let date: Date
+    let words: Int
+    let characters: Int
+    let sessions: Int
+    let recordingDuration: TimeInterval
+    let processingDuration: TimeInterval
+    let processingSamples: Int
+
+    var id: Date { date }
+
+    var averageWordsPerSession: Double {
+        guard sessions > 0 else { return 0 }
+        return Double(words) / Double(sessions)
+    }
+
+    var averageWPM: Double {
+        guard recordingDuration > 0 else { return 0 }
+        return Double(words) / (recordingDuration / 60.0)
+    }
+
+    var averageProcessingTime: TimeInterval {
+        guard processingSamples > 0 else { return 0 }
+        return processingDuration / Double(processingSamples)
+    }
+
+    var activityScore: Double {
+        Double(words)
+            + Double(characters) / 12.0
+            + Double(sessions) * 80.0
+            + recordingDuration / 3.0
+            + processingDuration / 3.0
+    }
+
+    static func empty(date: Date) -> DailyTranscriptionSummary {
+        DailyTranscriptionSummary(
+            date: date,
+            words: 0,
+            characters: 0,
+            sessions: 0,
+            recordingDuration: 0,
+            processingDuration: 0,
+            processingSamples: 0
+        )
+    }
+}
+
+private struct DashboardAggregate {
+    private static let estimatedTypingWordsPerMinute: Double = 45.0
+
+    let words: Int
+    let characters: Int
+    let sessions: Int
+    let activeDays: Int
+    let recordingDuration: TimeInterval
+    let processingDuration: TimeInterval
+    let processingSamples: Int
+    let peakDailyWords: Int
+
+    var averageWPM: Double {
+        guard recordingDuration > 0 else { return 0 }
+        return Double(words) / (recordingDuration / 60.0)
+    }
+
+    var averageProcessingTime: TimeInterval {
+        guard processingSamples > 0 else { return 0 }
+        return processingDuration / Double(processingSamples)
+    }
+
+    var estimatedTimeSaved: TimeInterval {
+        let typingMinutes = Double(words) / Self.estimatedTypingWordsPerMinute
+        return max(0, typingMinutes * 60.0 - recordingDuration)
+    }
+}
+
+private struct ActivityDataPoint: Identifiable, Equatable {
+    let date: Date
+    let value: Double
+    let sessions: Int
+    let characters: Int
+    let recordingDuration: TimeInterval
+    let processingDuration: TimeInterval
+
+    var id: Date { date }
+}
+
 internal struct DashboardHomeView: View {
+    private static let minimumActivityDays = 53 * 7
+
     @Binding var selectedNav: DashboardNavItem
     @State private var metricsStore = UsageMetricsStore.shared
-    @State private var sourceUsageStore = SourceUsageStore.shared
+    @State private var sourceStore = SourceUsageStore.shared
+    @ObservedObject private var languageManager = LanguageManager.shared
 
     @State private var recentRecords: [TranscriptionRecord] = []
-    @State private var dailyActivity: [Date: Int] = [:]
-    @State private var providerStats: [(provider: String, words: Int, icon: String)] = []
+    @State private var dailySummaries: [Date: DailyTranscriptionSummary] = [:]
+    @State private var selectedDate: Date?
+    @State private var hoveredTrendPoint: ActivityDataPoint?
+    @State private var trendHoverLocation: CGPoint?
+
+    private let metricColumns = [
+        GridItem(.flexible(minimum: 170), spacing: 12),
+        GridItem(.flexible(minimum: 170), spacing: 12),
+        GridItem(.flexible(minimum: 170), spacing: 12)
+    ]
+
+    private let detailColumns = [
+        GridItem(.adaptive(minimum: 150, maximum: 220), spacing: 12)
+    ]
 
     var body: some View {
-        Form {
-            Section("This Month") {
-                LabeledContent("Words") {
-                    Text(formatNumber(metricsStore.snapshot.totalWords))
-                        .monospacedDigit()
-                }
-
-                LabeledContent("Time Saved") {
-                    Text(formatDuration(metricsStore.snapshot.estimatedTimeSaved))
-                        .monospacedDigit()
-                }
-
-                LabeledContent("Avg. WPM") {
-                    Text(formatDecimal(metricsStore.snapshot.wordsPerMinute))
-                        .monospacedDigit()
-                }
-
-                if activeDays > 0 {
-                    LabeledContent("Active Days") {
-                        Text("\(activeDays)")
-                            .monospacedDigit()
-                    }
-                }
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                headerSection
+                overviewMetrics
+                activityCalendarSection
+                selectedDaySection
+                distributionSection
+                trendSection
+                recentTranscriptsSection
             }
-
-            Section {
-                ActivityHeatmapView(
-                    dailyActivity: dailyActivity,
-                    colorForCount: heatmapColor(for:),
-                    tooltip: heatmapTooltip(date:words:),
-                    weeks: generateActivityWeeks()
-                )
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, 4)
-
-                if streak > 0 {
-                    LabeledContent("Streak") {
-                        Text("\(streak) day\(streak == 1 ? "" : "s")")
-                            .monospacedDigit()
-                    }
-                }
-            } header: {
-                Text("Activity")
-            } footer: {
-                Text("Words transcribed over the last 28 days.")
-            }
-
-            Section("Top Sources") {
-                topSourcesSection
-            }
-
-            Section("Recent Transcripts") {
-                recentSection
-            }
+            .padding(24)
+            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
         }
+        .background(DashboardTheme.pageBg)
         .formStyle(.grouped)
+        .id(languageManager.current)
         .onAppear {
             loadDashboardData()
         }
     }
 
-    private var activeDays: Int {
-        dailyActivity.filter { $0.value > 0 }.count
+    private var aggregate: DashboardAggregate {
+        makeAggregate(records: recentRecords, summaries: Array(dailySummaries.values), snapshot: metricsStore.snapshot)
     }
 
-    private var streak: Int {
-        calculateStreak()
+    private var sortedSummaries: [DailyTranscriptionSummary] {
+        dailySummaries.values.sorted { $0.date < $1.date }
     }
 
-    private var topSourcesSection: some View {
-        let sourceStats = sourceUsageStore.topSources(limit: 5)
+    private var selectedDay: Date {
+        let calendar = Calendar.current
+        if let selectedDate {
+            return calendar.startOfDay(for: selectedDate)
+        }
+        return sortedSummaries.last(where: { $0.words > 0 })?.date
+            ?? calendar.startOfDay(for: Date())
+    }
 
-        return Group {
-            if sourceStats.isEmpty && providerStats.isEmpty {
-                Text("No sources yet.")
-                    .foregroundStyle(.secondary)
-            } else if !sourceStats.isEmpty {
-                ForEach(sourceStats.prefix(5)) { stat in
-                    HStack(spacing: 10) {
-                        appIcon(for: stat)
+    private var selectedSummary: DailyTranscriptionSummary {
+        dailySummaries[selectedDay] ?? .empty(date: selectedDay)
+    }
 
-                        Text(stat.displayName)
-                            .lineLimit(1)
+    private var selectedRecords: [TranscriptionRecord] {
+        let calendar = Calendar.current
+        return recentRecords.filter { calendar.isDate($0.date, inSameDayAs: selectedDay) }
+            .sorted { $0.date > $1.date }
+    }
 
-                        Spacer()
+    private var selectedProviderRows: [BreakdownRow] {
+        let rows = makeBreakdown(records: selectedRecords, label: providerLabel(for:))
+        guard rows.isEmpty, selectedSummary.words > 0 else {
+            return rows
+        }
+        return [
+            legacyBreakdownRow(
+                words: selectedSummary.words,
+                characters: selectedSummary.characters,
+                sessions: selectedSummary.sessions,
+                recordingDuration: selectedSummary.recordingDuration,
+                processingDuration: selectedSummary.processingDuration,
+                processingSamples: selectedSummary.processingSamples
+            )
+        ]
+    }
 
-                        Text(formatNumber(stat.totalWords))
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
-                    }
+    private var allProviderRows: [BreakdownRow] {
+        rowsWithLegacySummary(makeBreakdown(records: recentRecords, label: providerLabel(for:)))
+    }
+
+    private var allSourceRows: [BreakdownRow] {
+        let sourceRows = makeBreakdown(sources: sourceStore.allSources())
+        if !sourceRows.isEmpty {
+            return sourceRows
+        }
+        return makeBreakdown(records: recentRecords) { record in
+            record.sourceAppName?.isEmpty == false
+                ? record.sourceAppName!
+                : providerLabel(for: record)
+        }
+    }
+
+    private var allModelRows: [BreakdownRow] {
+        rowsWithLegacySummary(makeBreakdown(records: recentRecords) { record in
+            if let model = record.modelUsed, !model.isEmpty {
+                return model
+            }
+            return providerLabel(for: record)
+        })
+    }
+
+    private var trendPoints: [ActivityDataPoint] {
+        Array(sortedSummaries.suffix(45)).map {
+            ActivityDataPoint(
+                date: $0.date,
+                value: Double($0.words),
+                sessions: $0.sessions,
+                characters: $0.characters,
+                recordingDuration: $0.recordingDuration,
+                processingDuration: $0.processingDuration
+            )
+        }
+    }
+
+    private var trendYUpperBound: Double {
+        let maxValue = trendPoints.map(\.value).max() ?? 0
+        return max(1, maxValue * 1.14)
+    }
+
+    private var activeWeeks: [[Date]] {
+        generateActivityWeeks()
+    }
+
+    private var maxActivityValue: Double {
+        max(sortedSummaries.map(\.activityScore).max() ?? 0, 1)
+    }
+
+    private var headerSection: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(L10n.Home.statsTitle)
+                    .font(.system(size: 34, weight: .bold))
+                    .foregroundStyle(DashboardTheme.ink)
+
+                Text(L10n.Home.statsSubtitle)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(DashboardTheme.inkLight)
+            }
+
+            Spacer()
+
+            Button {
+                selectedNav = .transcripts
+            } label: {
+                Label(L10n.Home.viewAll, systemImage: "doc.text.magnifyingglass")
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    private var overviewMetrics: some View {
+        LazyVGrid(columns: metricColumns, spacing: 12) {
+            StatTile(
+                title: L10n.Home.words,
+                value: formatCompactNumber(aggregate.words),
+                subtitle: L10n.Home.allSavedRecords,
+                systemImage: "text.word.spacing",
+                tint: DashboardTheme.success
+            )
+
+            StatTile(
+                title: L10n.Home.sessions,
+                value: formatNumber(aggregate.sessions),
+                subtitle: L10n.Home.activeDaysSummary(aggregate.activeDays),
+                systemImage: "waveform",
+                tint: DashboardTheme.accent
+            )
+
+            StatTile(
+                title: L10n.Home.timeSaved,
+                value: formatDuration(aggregate.estimatedTimeSaved),
+                subtitle: L10n.Home.basedOnTypingSpeed,
+                systemImage: "keyboard.badge.clock",
+                tint: Color(nsColor: .systemTeal)
+            )
+
+            StatTile(
+                title: L10n.Home.avgTranscriptionTime,
+                value: formatDurationPrecise(aggregate.averageProcessingTime),
+                subtitle: L10n.Home.processingAverage,
+                systemImage: "speedometer",
+                tint: Color(nsColor: .systemOrange)
+            )
+
+            StatTile(
+                title: L10n.Home.avgWPM,
+                value: formatDecimal(aggregate.averageWPM),
+                subtitle: L10n.Home.recordingBased,
+                systemImage: "gauge.with.dots.needle.33percent",
+                tint: Color(nsColor: .systemPurple)
+            )
+
+            StatTile(
+                title: L10n.Home.peakDay,
+                value: formatCompactNumber(aggregate.peakDailyWords),
+                subtitle: L10n.Home.bestSingleDay,
+                systemImage: "chart.line.uptrend.xyaxis",
+                tint: Color(nsColor: .systemGreen)
+            )
+        }
+    }
+
+    private var activityCalendarSection: some View {
+        StatsPanel {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(alignment: .top, spacing: 16) {
+                    activityCalendarTitle
+                    Spacer(minLength: 18)
                 }
-            } else {
-                ForEach(providerStats.prefix(5), id: \.provider) { stat in
-                    HStack(spacing: 10) {
-                        Image(systemName: stat.icon)
-                            .foregroundStyle(.secondary)
-                            .frame(width: 18)
 
-                        Text(providerDisplayName(for: stat.provider))
-                            .lineLimit(1)
-
-                        Spacer()
-
-                        Text(formatNumber(stat.words))
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
+                ActivityCalendarView(
+                    weeks: activeWeeks,
+                    summaries: dailySummaries,
+                    selectedDate: selectedDay,
+                    maxValue: maxActivityValue,
+                    onSelect: { date in
+                        selectedDate = Calendar.current.startOfDay(for: date)
                     }
+                )
+
+                HStack(spacing: 10) {
+                    Text(L10n.Home.calendarHint)
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(DashboardTheme.inkMuted)
+                    Spacer()
+                    HeatLegend(tint: DashboardTheme.success)
                 }
             }
         }
     }
 
-    private var recentSection: some View {
-        Group {
-            if recentRecords.isEmpty {
-                Text("No transcripts yet.")
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(Array(recentRecords.prefix(5).enumerated()), id: \.element.id) { _, record in
-                    VStack(alignment: .leading, spacing: 2) {
-                        HStack(spacing: 8) {
-                            if let iconData = record.sourceAppIconData,
-                               let nsImage = NSImage(data: iconData) {
-                                Image(nsImage: nsImage)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 16, height: 16)
-                                    .clipShape(RoundedRectangle(cornerRadius: 3))
-                            }
+    private var activityCalendarTitle: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(L10n.Home.calendarTitle)
+                .font(.title2.weight(.bold))
+                .foregroundStyle(DashboardTheme.ink)
+            Text(L10n.Home.calendarSubtitle)
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(DashboardTheme.inkLight)
+        }
+    }
 
-                            Text(record.sourceAppName ?? providerDisplayName(for: record.provider))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+    private var selectedDaySection: some View {
+        StatsPanel {
+            VStack(alignment: .leading, spacing: 18) {
+                HStack(alignment: .top, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(Self.dayTitleFormatter.string(from: selectedDay))
+                            .font(.system(size: 24, weight: .bold, design: .rounded))
+                            .monospacedDigit()
+                            .foregroundStyle(DashboardTheme.ink)
 
-                            Spacer(minLength: 0)
+                        Text(L10n.Home.dayOverview)
+                            .font(.title3.weight(.bold))
+                            .foregroundStyle(DashboardTheme.success)
 
-                            Text(formatTime(record.date))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .monospacedDigit()
+                        Text(selectedDaySummaryLine)
+                            .font(.callout.weight(.semibold))
+                            .foregroundStyle(DashboardTheme.inkLight)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Text(dayContextLine)
+                            .font(.callout.weight(.semibold))
+                            .foregroundStyle(DashboardTheme.inkLight)
+                    }
+
+                    Spacer(minLength: 18)
+
+                    LazyVGrid(columns: detailColumns, spacing: 12) {
+                        CompactMetricTile(title: L10n.Home.words, value: formatCompactNumber(selectedSummary.words), tint: DashboardTheme.success)
+                        CompactMetricTile(title: L10n.Home.characters, value: formatCompactNumber(selectedSummary.characters), tint: DashboardTheme.accent)
+                        CompactMetricTile(title: L10n.Home.recordingDuration, value: formatDurationPrecise(selectedSummary.recordingDuration), tint: Color(nsColor: .systemCyan))
+                        CompactMetricTile(title: L10n.Home.processingDuration, value: formatDurationPrecise(selectedSummary.processingDuration), tint: Color(nsColor: .systemOrange))
+                        CompactMetricTile(title: L10n.Home.avgWPM, value: formatDecimal(selectedSummary.averageWPM), tint: Color(nsColor: .systemPurple))
+                        CompactMetricTile(title: L10n.Home.avgProcessing, value: formatDurationPrecise(selectedSummary.averageProcessingTime), tint: Color(nsColor: .systemTeal))
+                    }
+                    .frame(maxWidth: 520)
+                }
+
+                if selectedSummary.words == 0 {
+                    EmptyStatsRow(text: L10n.Home.noDataForDay)
+                } else if selectedRecords.isEmpty {
+                    EmptyStatsRow(text: L10n.Home.aggregateOnlyDay)
+                } else {
+                    Divider()
+
+                    HStack(alignment: .top, spacing: 22) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text(L10n.Home.providerMix)
+                                .font(.headline)
+                            DonutBreakdownView(
+                                rows: selectedProviderRows,
+                                total: max(selectedSummary.words, 1),
+                                color: providerColor(for:)
+                            )
+                            .frame(width: 128, height: 128)
                         }
 
-                        Text(record.text)
-                            .lineLimit(2)
-                    }
-                    .padding(.vertical, 2)
-                }
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text(L10n.Home.dayBreakdown)
+                                .font(.headline)
+                            ForEach(selectedProviderRows.prefix(5)) { row in
+                                BreakdownLine(
+                                    row: row,
+                                    totalWords: max(selectedSummary.words, 1),
+                                    tint: providerColor(for: row.label),
+                                    value: "\(formatCompactNumber(row.words)) · \(row.sessions)"
+                                )
+                            }
+                        }
+                        .frame(minWidth: 240, maxWidth: .infinity, alignment: .leading)
 
-                Button("View All…") {
-                    selectedNav = .transcripts
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text(L10n.Home.modelBreakdown)
+                                .font(.headline)
+                            ForEach(makeBreakdown(records: selectedRecords, label: modelLabel(for:)).prefix(5)) { row in
+                                BreakdownLine(
+                                    row: row,
+                                    totalWords: max(selectedSummary.words, 1),
+                                    tint: modelColor(for: row.label),
+                                    value: formatDurationPrecise(row.averageProcessingTime)
+                                )
+                            }
+                        }
+                        .frame(minWidth: 260, maxWidth: .infinity, alignment: .leading)
+                    }
                 }
             }
         }
     }
 
-    private func appIcon(for stat: SourceUsageStats) -> some View {
-        Group {
-            if let image = stat.nsImage() {
-                Image(nsImage: image)
-                    .resizable()
-                    .scaledToFit()
-            } else {
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(Color(nsColor: .quaternaryLabelColor).opacity(0.35))
-                    .overlay(
-                        Text(stat.initials.uppercased())
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                    )
+    private var distributionSection: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: 14) {
+                providerDistributionPanel
+                    .frame(minWidth: 280, maxWidth: .infinity, alignment: .topLeading)
+                sourceDistributionPanel
+                    .frame(minWidth: 280, maxWidth: .infinity, alignment: .topLeading)
+                modelDistributionPanel
+                    .frame(minWidth: 280, maxWidth: .infinity, alignment: .topLeading)
+            }
+
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .top, spacing: 14) {
+                    providerDistributionPanel
+                        .frame(minWidth: 280, maxWidth: .infinity, alignment: .topLeading)
+                    sourceDistributionPanel
+                        .frame(minWidth: 280, maxWidth: .infinity, alignment: .topLeading)
+                }
+
+                modelDistributionPanel
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+
+            VStack(alignment: .leading, spacing: 14) {
+                providerDistributionPanel
+                sourceDistributionPanel
+                modelDistributionPanel
             }
         }
-        .frame(width: 18, height: 18)
-        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private var providerDistributionPanel: some View {
+        BreakdownPanel(
+            title: L10n.Home.providerMix,
+            rows: allProviderRows,
+            totalWords: max(aggregate.words, 1),
+            color: providerColor(for:),
+            valueFormatter: { row in "\(formatCompactNumber(row.words)) · \(row.sessions)" }
+        )
+    }
+
+    private var sourceDistributionPanel: some View {
+        BreakdownPanel(
+            title: L10n.Home.sourceMix,
+            rows: allSourceRows,
+            totalWords: max(aggregate.words, 1),
+            color: sourceColor(for:),
+            valueFormatter: { row in "\(formatCompactNumber(row.words)) · \(formatCompactNumber(row.characters))" }
+        )
+    }
+
+    private var modelDistributionPanel: some View {
+        BreakdownPanel(
+            title: L10n.Home.modelBreakdown,
+            rows: allModelRows,
+            totalWords: max(aggregate.words, 1),
+            color: modelColor(for:),
+            valueFormatter: { row in "\(formatCompactNumber(row.words)) · \(formatDurationPrecise(row.averageProcessingTime))" }
+        )
+    }
+
+    private var trendSection: some View {
+        StatsPanel {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(L10n.Home.trendTitle)
+                            .font(.title3.weight(.bold))
+                        Text(L10n.Home.trendSubtitle)
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(DashboardTheme.inkMuted)
+                    }
+                    Spacer()
+                    Text(L10n.Home.words)
+                        .font(.footnote.weight(.bold))
+                        .foregroundStyle(DashboardTheme.success)
+                }
+
+                if trendPoints.contains(where: { $0.value > 0 }) {
+                    Chart {
+                        ForEach(trendPoints) { point in
+                            BarMark(
+                                x: .value(L10n.Home.date, point.date, unit: .day),
+                                y: .value(L10n.Home.words, point.value)
+                            )
+                            .foregroundStyle(DashboardTheme.success.gradient)
+                            .cornerRadius(3)
+                        }
+
+                        if let hoveredTrendPoint {
+                            RuleMark(x: .value(L10n.Home.date, hoveredTrendPoint.date, unit: .day))
+                                .foregroundStyle(DashboardTheme.inkMuted.opacity(0.55))
+                                .lineStyle(.init(lineWidth: 1, dash: [4, 4]))
+                        }
+                    }
+                    .chartYScale(domain: 0...trendYUpperBound)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 6)) { value in
+                            AxisGridLine()
+                            AxisTick()
+                            AxisValueLabel {
+                                if let date = value.as(Date.self) {
+                                    Text(Self.shortDateFormatter.string(from: date))
+                                }
+                            }
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { value in
+                            AxisGridLine()
+                            AxisValueLabel {
+                                if let doubleValue = value.as(Double.self) {
+                                    Text(formatCompactNumber(Int(doubleValue.rounded())))
+                                }
+                            }
+                        }
+                    }
+                    .chartOverlay { proxy in
+                        GeometryReader { geometry in
+                            Rectangle()
+                                .fill(.clear)
+                                .contentShape(Rectangle())
+                                .onContinuousHover { phase in
+                                    updateTrendHover(phase: phase, proxy: proxy, geometry: geometry)
+                            }
+                        }
+                    }
+                    .overlay {
+                        GeometryReader { geometry in
+                            if let hoveredTrendPoint, let trendHoverLocation {
+                                let x = min(max(trendHoverLocation.x, 104), max(104, geometry.size.width - 104))
+                                let y = min(max(trendHoverLocation.y, 72), max(72, geometry.size.height - 72))
+
+                                TrendHoverTooltip(
+                                    date: Self.trendTooltipFormatter.string(from: hoveredTrendPoint.date),
+                                    words: formatCompactNumber(Int(hoveredTrendPoint.value.rounded())),
+                                    characters: formatCompactNumber(hoveredTrendPoint.characters),
+                                    sessions: formatNumber(hoveredTrendPoint.sessions),
+                                    recordingDuration: formatDurationPrecise(hoveredTrendPoint.recordingDuration),
+                                    processingDuration: formatDurationPrecise(hoveredTrendPoint.processingDuration)
+                                )
+                                .position(x: x, y: y)
+                            }
+                        }
+                        .allowsHitTesting(false)
+                    }
+                    .frame(height: 170)
+                } else {
+                    EmptyStatsRow(text: L10n.Home.noTrendData)
+                        .frame(height: 120)
+                }
+            }
+        }
+    }
+
+    private var recentTranscriptsSection: some View {
+        StatsPanel {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text(L10n.Home.recentTranscripts)
+                        .font(.title3.weight(.bold))
+                    Spacer()
+                    Button(L10n.Home.viewAll) {
+                        selectedNav = .transcripts
+                    }
+                    .buttonStyle(.borderless)
+                }
+
+                if recentRecords.isEmpty {
+                    EmptyStatsRow(text: L10n.Home.noTranscripts)
+                } else {
+                    VStack(spacing: 0) {
+                        ForEach(Array(recentRecords.prefix(6).enumerated()), id: \.element.id) { index, record in
+                            RecentTranscriptRow(
+                                record: record,
+                                providerColor: providerColor(for: providerLabel(for: record)),
+                                timeFormatter: Self.timeFormatter,
+                                numberFormatter: Self.integerFormatter
+                            )
+                            if index < min(recentRecords.count, 6) - 1 {
+                                Divider()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var dayContextLine: String {
+        if selectedRecords.isEmpty, selectedSummary.words > 0 {
+            return L10n.Home.aggregateOnlyDay
+        }
+        let peakShare = aggregate.peakDailyWords > 0
+            ? Double(selectedSummary.words) / Double(aggregate.peakDailyWords) * 100
+            : 0
+        let weekWords = wordsInSelectedWeek()
+        let weekShare = weekWords > 0 ? Double(selectedSummary.words) / Double(weekWords) * 100 : 0
+        return L10n.Home.dayContext(
+            sessions: selectedSummary.sessions,
+            peakPercent: peakShare,
+            weekPercent: weekShare
+        )
+    }
+
+    private var selectedDaySummaryLine: String {
+        [
+            "\(formatCompactNumber(selectedSummary.words)) \(L10n.Home.words)",
+            "\(formatNumber(selectedSummary.sessions)) \(L10n.Home.sessions)",
+            "\(formatDurationPrecise(selectedSummary.recordingDuration)) \(L10n.Home.recordingDuration)",
+            "\(formatDurationPrecise(selectedSummary.processingDuration)) \(L10n.Home.processingDuration)"
+        ].joined(separator: " · ")
+    }
+
+    private func loadDashboardData() {
+        Task {
+            await metricsStore.bootstrapIfNeeded()
+
+            let records = await DataManager.shared.fetchAllRecordsQuietly()
+            await MainActor.run {
+                recentRecords = records
+                dailySummaries = makeDailySummaries(records: records, snapshot: metricsStore.snapshot)
+                if selectedDate == nil {
+                    selectedDate = dailySummaries.values
+                        .filter { $0.words > 0 }
+                        .map(\.date)
+                        .max()
+                        ?? Calendar.current.startOfDay(for: Date())
+                }
+            }
+        }
+    }
+
+    private func updateTrendHover(phase: HoverPhase, proxy: ChartProxy, geometry: GeometryProxy) {
+        switch phase {
+        case .active(let location):
+            guard let plotFrameAnchor = proxy.plotFrame else {
+                hoveredTrendPoint = nil
+                trendHoverLocation = nil
+                return
+            }
+            let plotFrame = geometry[plotFrameAnchor]
+            guard plotFrame.contains(location) else {
+                hoveredTrendPoint = nil
+                trendHoverLocation = nil
+                return
+            }
+
+            let x = location.x - plotFrame.origin.x
+            guard let hoveredDate: Date = proxy.value(atX: x) else {
+                hoveredTrendPoint = nil
+                trendHoverLocation = nil
+                return
+            }
+
+            hoveredTrendPoint = nearestTrendPoint(to: hoveredDate)
+            trendHoverLocation = location
+        case .ended:
+            hoveredTrendPoint = nil
+            trendHoverLocation = nil
+        }
+    }
+
+    private func nearestTrendPoint(to date: Date) -> ActivityDataPoint? {
+        guard let nearest = trendPoints.min(by: {
+            abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date))
+        }) else {
+            return nil
+        }
+
+        guard nearest.value > 0 else {
+            return nil
+        }
+
+        let maxDistance = TimeInterval(18 * 60 * 60)
+        return abs(nearest.date.timeIntervalSince(date)) <= maxDistance ? nearest : nil
     }
 }
 
-// MARK: - Activity Heatmap
+// MARK: - Activity Calendar
 
-private struct ActivityHeatmapView: View {
-    let dailyActivity: [Date: Int]
-    let colorForCount: (Int) -> Color
-    let tooltip: (Date, Int) -> String
+private struct ActivityDayHitTarget: NSViewRepresentable {
+    let isEnabled: Bool
+    let accessibilityLabel: String
+    let accessibilityValue: String
+    let onPress: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton(frame: .zero)
+        button.title = ""
+        button.isBordered = false
+        button.isTransparent = true
+        button.setButtonType(.momentaryChange)
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.press(_:))
+        configure(button)
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        context.coordinator.parent = self
+        configure(button)
+    }
+
+    private func configure(_ button: NSButton) {
+        button.isEnabled = isEnabled
+        button.setAccessibilityLabel(accessibilityLabel)
+        button.setAccessibilityValue(accessibilityValue)
+    }
+
+    final class Coordinator: NSObject {
+        var parent: ActivityDayHitTarget
+
+        init(_ parent: ActivityDayHitTarget) {
+            self.parent = parent
+        }
+
+        @objc func press(_ sender: NSButton) {
+            guard parent.isEnabled else {
+                return
+            }
+            parent.onPress()
+        }
+    }
+}
+
+private struct ActivityCalendarView: View {
     let weeks: [[Date]]
+    let summaries: [Date: DailyTranscriptionSummary]
+    let selectedDate: Date
+    let maxValue: Double
+    let onSelect: (Date) -> Void
+
+    private let cellSize: CGFloat = 14
+    private let hitSize: CGFloat = 22
+    private let cellGap: CGFloat = 2
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
-                ForEach(["S", "M", "T", "W", "T", "F", "S"], id: \.self) { day in
+        HStack(alignment: .top, spacing: 10) {
+            VStack(spacing: cellGap) {
+                ForEach(Array(L10n.Weekday.short.enumerated()), id: \.offset) { _, day in
                     Text(day)
                         .font(.caption2.weight(.medium))
-                        .foregroundStyle(.secondary)
-                        .frame(width: 16)
+                        .foregroundStyle(DashboardTheme.inkMuted)
+                        .frame(width: 18, height: hitSize)
                 }
             }
+            .padding(.top, 2)
 
-            VStack(spacing: 6) {
-                ForEach(0..<min(weeks.count, 4), id: \.self) { weekIndex in
-                    HStack(spacing: 6) {
-                        ForEach(0..<min(weeks[weekIndex].count, 7), id: \.self) { dayIndex in
-                            let date = weeks[weekIndex][dayIndex]
-                            let count = dailyActivity[Calendar.current.startOfDay(for: date)] ?? 0
-
-                            RoundedRectangle(cornerRadius: 2)
-                                .fill(colorForCount(count))
-                                .frame(width: 16, height: 16)
-                                .help(tooltip(date, count))
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(alignment: .top, spacing: cellGap) {
+                            ForEach(weeks.indices, id: \.self) { weekIndex in
+                                VStack(spacing: cellGap) {
+                                    ForEach(weeks[weekIndex], id: \.self) { date in
+                                        dayCell(for: date)
+                                    }
+                                }
+                                .id(weekIndex)
+                            }
                         }
+
+                        HStack(alignment: .top, spacing: cellGap) {
+                            ForEach(weeks.indices, id: \.self) { weekIndex in
+                                Text(monthLabel(for: weekIndex))
+                                    .font(.caption2.weight(.bold))
+                                    .foregroundStyle(DashboardTheme.inkMuted)
+                                    .lineLimit(1)
+                                    .fixedSize(horizontal: true, vertical: false)
+                                    .frame(width: hitSize, alignment: .leading)
+                            }
+                        }
+                        .frame(height: 16, alignment: .leading)
+                    }
+                    .padding(.vertical, 2)
+                }
+                .onAppear {
+                    scrollToLatestWeek(using: proxy)
+                }
+                .onChange(of: weeks.count) { _, _ in
+                    scrollToLatestWeek(using: proxy)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func dayCell(for date: Date) -> some View {
+        let calendar = Calendar.current
+        let day = calendar.startOfDay(for: date)
+        let today = calendar.startOfDay(for: Date())
+        let summary = summaries[day] ?? .empty(date: day)
+        let value = summary.activityScore
+        let isFuture = day > today
+        let isSelected = calendar.isDate(day, inSameDayAs: selectedDate)
+        let accessibilityTitle = Self.tooltipFormatter.string(from: day)
+        let accessibilityValue = activitySummaryText(for: summary)
+
+        ZStack {
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .fill(color(for: value, future: isFuture))
+                .frame(width: cellSize, height: cellSize)
+                .overlay {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .stroke(Color.primary.opacity(0.92), lineWidth: 2)
+                            .padding(-2)
+                    }
+                }
+
+            ActivityDayHitTarget(
+                isEnabled: !isFuture,
+                accessibilityLabel: accessibilityTitle,
+                accessibilityValue: accessibilityValue
+            ) {
+                onSelect(day)
+            }
+            .frame(width: hitSize, height: hitSize)
+        }
+        .frame(width: hitSize, height: hitSize)
+        .contentShape(Rectangle())
+        .help(accessibilityTitle + " · " + accessibilityValue)
+    }
+
+    private func color(for value: Double, future: Bool) -> Color {
+        guard !future else {
+            return DashboardTheme.inkFaint.opacity(0.10)
+        }
+        guard value > 0 else {
+            return DashboardTheme.inkFaint.opacity(0.22)
+        }
+        let intensity = min(max(value / maxValue, 0.14), 1.0)
+        return DashboardTheme.success.opacity(0.18 + 0.72 * intensity)
+    }
+
+    private func monthLabel(for weekIndex: Int) -> String {
+        guard weeks.indices.contains(weekIndex),
+              let firstDay = weeks[weekIndex].first else {
+            return ""
+        }
+        let calendar = Calendar.current
+        if weekIndex == 0 {
+            if weeks.indices.contains(1),
+               let nextFirstDay = weeks[1].first,
+               calendar.component(.month, from: firstDay) != calendar.component(.month, from: nextFirstDay) {
+                return ""
+            }
+            return Self.monthFormatter.string(from: firstDay)
+        }
+        guard let previousFirstDay = weeks[weekIndex - 1].first else {
+            return ""
+        }
+        return calendar.component(.month, from: firstDay) != calendar.component(.month, from: previousFirstDay)
+            ? Self.monthFormatter.string(from: firstDay)
+            : ""
+    }
+
+    private func scrollToLatestWeek(using proxy: ScrollViewProxy) {
+        guard let lastWeekIndex = weeks.indices.last else {
+            return
+        }
+        DispatchQueue.main.async {
+            proxy.scrollTo(lastWeekIndex, anchor: .trailing)
+        }
+    }
+
+    private static let monthFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM")
+        return formatter
+    }()
+
+    private static let tooltipFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    private static let dayIdentifierFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    private func activitySummaryText(for summary: DailyTranscriptionSummary) -> String {
+        guard summary.words > 0 || summary.sessions > 0 else {
+            return L10n.Home.noDataForDay
+        }
+        return [
+            "\(formatCompactNumber(summary.words)) \(L10n.Home.words)",
+            "\(formatNumber(summary.sessions)) \(L10n.Home.sessions)",
+            "\(formatDurationPrecise(summary.recordingDuration)) \(L10n.Home.recordingDuration)",
+            "\(formatDurationPrecise(summary.processingDuration)) \(L10n.Home.processingDuration)"
+        ].joined(separator: " · ")
+    }
+
+    private func formatNumber(_ value: Int) -> String {
+        Self.integerFormatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    private func formatCompactNumber(_ value: Int) -> String {
+        if L10n.isChinese {
+            if value >= 100_000_000 {
+                return String(format: "%.2f亿", Double(value) / 100_000_000)
+            }
+            if value >= 10_000 {
+                return String(format: "%.1f万", Double(value) / 10_000)
+            }
+            return formatNumber(value)
+        }
+        if value >= 1_000_000 {
+            return String(format: "%.1fM", Double(value) / 1_000_000)
+        }
+        if value >= 10_000 {
+            return String(format: "%.1fK", Double(value) / 1_000)
+        }
+        return formatNumber(value)
+    }
+
+    private func formatDurationPrecise(_ interval: TimeInterval) -> String {
+        guard interval.isFinite, interval > 0 else { return "0s" }
+        let totalSeconds = Int(interval.rounded())
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        if minutes > 0 {
+            return "\(minutes)m \(seconds)s"
+        }
+        return "\(seconds)s"
+    }
+
+    private static let integerFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter
+    }()
+}
+
+// MARK: - Small Views
+
+private struct StatsPanel<Content: View>: View {
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            content
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(DashboardTheme.cardBg)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(DashboardTheme.rule.opacity(0.75), lineWidth: 1)
+        )
+    }
+}
+
+private struct StatTile: View {
+    let title: String
+    let value: String
+    let subtitle: String
+    let systemImage: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(tint)
+                    .frame(width: 26, height: 26)
+                    .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(DashboardTheme.inkLight)
+                    .lineLimit(1)
+            }
+
+            Text(value)
+                .font(.system(size: 26, weight: .heavy, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(DashboardTheme.ink)
+                .minimumScaleFactor(0.75)
+                .lineLimit(1)
+
+            Text(subtitle)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(DashboardTheme.inkMuted)
+                .lineLimit(1)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, minHeight: 126, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(DashboardTheme.cardBgAlt)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(DashboardTheme.rule.opacity(0.55), lineWidth: 1)
+        )
+    }
+}
+
+private struct CompactMetricTile: View {
+    let title: String
+    let value: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(title)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(DashboardTheme.inkMuted)
+                .lineLimit(1)
+
+            Text(value)
+                .font(.system(size: 18, weight: .heavy, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(tint)
+                .minimumScaleFactor(0.75)
+                .lineLimit(1)
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DashboardTheme.accentSubtle, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct DonutBreakdownView: View {
+    let rows: [BreakdownRow]
+    let total: Int
+    let color: (String) -> Color
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(DashboardTheme.inkFaint.opacity(0.22), lineWidth: 18)
+
+            ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
+                Circle()
+                    .trim(from: segment.start, to: segment.end)
+                    .stroke(
+                        color(segment.row.label),
+                        style: StrokeStyle(lineWidth: 18, lineCap: .butt)
+                    )
+                    .rotationEffect(.degrees(-90))
+            }
+
+            VStack(spacing: 1) {
+                Text("\(rows.count)")
+                    .font(.system(size: 22, weight: .heavy, design: .rounded))
+                    .monospacedDigit()
+                Text(L10n.Home.providers)
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(DashboardTheme.inkMuted)
+            }
+        }
+    }
+
+    private var segments: [(row: BreakdownRow, start: CGFloat, end: CGFloat)] {
+        guard total > 0 else { return [] }
+        var cursor: CGFloat = 0
+        return rows.prefix(6).map { row in
+            let share = CGFloat(Double(row.words) / Double(total))
+            let start = cursor
+            cursor += max(share, row.words > 0 ? 0.015 : 0)
+            return (row: row, start: start, end: min(cursor, 1))
+        }
+    }
+}
+
+private struct BreakdownPanel: View {
+    let title: String
+    let rows: [BreakdownRow]
+    let totalWords: Int
+    let color: (String) -> Color
+    let valueFormatter: (BreakdownRow) -> String
+
+    var body: some View {
+        StatsPanel {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(DashboardTheme.ink)
+
+                if rows.isEmpty {
+                    EmptyStatsRow(text: L10n.Home.noBreakdownData)
+                } else {
+                    ForEach(rows.prefix(6)) { row in
+                        BreakdownLine(
+                            row: row,
+                            totalWords: totalWords,
+                            tint: color(row.label),
+                            value: valueFormatter(row)
+                        )
                     }
                 }
             }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+}
+
+private struct BreakdownLine: View {
+    let row: BreakdownRow
+    let totalWords: Int
+    let tint: Color
+    let value: String
+
+    private var share: Double {
+        guard totalWords > 0 else { return 0 }
+        return Double(row.words) / Double(totalWords)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(tint)
+                    .frame(width: 8, height: 8)
+
+                Text(row.label)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer(minLength: 8)
+
+                Text(value)
+                    .font(.subheadline.weight(.bold))
+                    .monospacedDigit()
+                    .foregroundStyle(tint)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+                    .allowsTightening(true)
+                    .layoutPriority(1)
+            }
+
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(DashboardTheme.inkFaint.opacity(0.16))
+                    Capsule()
+                        .fill(tint)
+                        .frame(width: max(6, geometry.size.width * share))
+                }
+            }
+            .frame(height: 6)
+        }
+    }
+}
+
+private struct HeatLegend: View {
+    let tint: Color
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(L10n.Home.less)
+            ForEach(0..<5, id: \.self) { index in
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(index == 0 ? DashboardTheme.inkFaint.opacity(0.22) : tint.opacity(0.18 + Double(index) * 0.16))
+                    .frame(width: 14, height: 14)
+            }
+            Text(L10n.Home.more)
+        }
+        .font(.caption2.weight(.semibold))
+        .foregroundStyle(DashboardTheme.inkMuted)
+    }
+}
+
+private struct EmptyStatsRow: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "tray")
+                .foregroundStyle(DashboardTheme.inkMuted)
+            Text(text)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(DashboardTheme.inkMuted)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 16)
+    }
+}
+
+private struct TrendHoverTooltip: View {
+    let date: String
+    let words: String
+    let characters: String
+    let sessions: String
+    let recordingDuration: String
+    let processingDuration: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(date)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(DashboardTheme.ink)
+
+            VStack(alignment: .leading, spacing: 5) {
+                tooltipRow(label: L10n.Home.words, value: words, tint: DashboardTheme.success)
+                tooltipRow(label: L10n.Home.characters, value: characters, tint: DashboardTheme.accent)
+                tooltipRow(label: L10n.Home.sessions, value: sessions, tint: DashboardTheme.providerGemini)
+                tooltipRow(label: L10n.Home.recordingDuration, value: recordingDuration, tint: Color(nsColor: .systemCyan))
+                tooltipRow(label: L10n.Home.processingDuration, value: processingDuration, tint: Color(nsColor: .systemOrange))
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(DashboardTheme.cardBgAlt.opacity(0.98))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(DashboardTheme.rule.opacity(0.9), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.22), radius: 12, y: 6)
+        .frame(width: 190, alignment: .leading)
+    }
+
+    private func tooltipRow(label: String, value: String, tint: Color) -> some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(tint)
+                .frame(width: 6, height: 6)
+            Text(label)
+                .foregroundStyle(DashboardTheme.inkMuted)
+            Spacer(minLength: 14)
+            Text(value)
+                .foregroundStyle(tint)
+                .fontWeight(.bold)
+                .monospacedDigit()
+        }
+        .font(.caption2.weight(.semibold))
+    }
+}
+
+private struct RecentTranscriptRow: View {
+    let record: TranscriptionRecord
+    let providerColor: Color
+    let timeFormatter: DateFormatter
+    let numberFormatter: NumberFormatter
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                sourceIcon
+
+                Text(record.sourceAppName ?? L10n.Provider.displayName(for: record.provider))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(DashboardTheme.inkLight)
+                    .lineLimit(1)
+
+                Text(L10n.Provider.displayName(for: record.provider))
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(providerColor)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(providerColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 5, style: .continuous))
+
+                if let processing = record.formattedTranscriptionTime {
+                    Text(processing)
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(Color(nsColor: .systemOrange))
+                }
+
+                Spacer(minLength: 8)
+
+                Text(timeFormatter.string(from: record.date))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(DashboardTheme.inkMuted)
+            }
+
+            Text(record.text)
+                .font(.subheadline)
+                .lineLimit(2)
+                .foregroundStyle(DashboardTheme.ink)
+
+            HStack(spacing: 12) {
+                Text(L10n.Home.wordsSuffix(record.wordCount > 0 ? record.wordCount : UsageMetricsStore.estimatedWordCount(for: record.text)))
+                if let duration = record.formattedDuration {
+                    Text(duration)
+                }
+                if let model = record.modelUsed, !model.isEmpty {
+                    Text(model)
+                        .lineLimit(1)
+                }
+            }
+            .font(.caption2.weight(.medium))
+            .foregroundStyle(DashboardTheme.inkMuted)
+        }
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private var sourceIcon: some View {
+        if let iconData = record.sourceAppIconData,
+           let nsImage = NSImage(data: iconData) {
+            Image(nsImage: nsImage)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 18, height: 18)
+                .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+        } else {
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(providerColor.opacity(0.16))
+                .overlay {
+                    Image(systemName: "text.cursor")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(providerColor)
+                }
+                .frame(width: 18, height: 18)
         }
     }
 }
@@ -229,149 +1382,339 @@ private struct ActivityHeatmapView: View {
 // MARK: - Data + Helpers
 
 private extension DashboardHomeView {
-    func loadDashboardData() {
-        Task {
-            await metricsStore.bootstrapIfNeeded()
-
-            let records = await DataManager.shared.fetchAllRecordsQuietly()
-            await MainActor.run {
-                recentRecords = records
-                calculateProviderStats(from: records)
-                calculateDailyActivity(from: records)
-            }
-        }
-    }
-
-    func calculateProviderStats(from records: [TranscriptionRecord]) {
-        var stats: [String: Int] = [:]
-        for record in records {
-            stats[record.provider, default: 0] += record.wordCount
-        }
-
-        providerStats = stats
-            .map { (provider: $0.key, words: $0.value, icon: providerIcon(for: $0.key)) }
-            .sorted { $0.words > $1.words }
-    }
-
-    func calculateDailyActivity(from records: [TranscriptionRecord]) {
-        // Start with aggregated activity (works even when history is disabled).
-        var activity = metricsStore.getDailyActivity(days: 28)
-
-        // Merge with history records, but avoid double-counting if the day already exists.
+    func makeDailySummaries(records: [TranscriptionRecord], snapshot: UsageSnapshot) -> [Date: DailyTranscriptionSummary] {
         let calendar = Calendar.current
-        for record in records {
-            let day = calendar.startOfDay(for: record.date)
-            if activity[day] == nil || activity[day] == 0 {
-                activity[day, default: 0] += record.wordCount
-            }
+        var output: [Date: DailyTranscriptionSummary] = [:]
+        var detailedWordsByDay: [Date: Int] = [:]
+
+        let grouped = Dictionary(grouping: records) { record in
+            calendar.startOfDay(for: record.date)
         }
 
-        dailyActivity = activity
+        for (day, dayRecords) in grouped {
+            let words = dayRecords.reduce(0) { $0 + wordCount(for: $1) }
+            let characters = dayRecords.reduce(0) { $0 + characterCount(for: $1) }
+            let recordingDuration = dayRecords.reduce(0) { $0 + ($1.duration ?? 0) }
+            let processingValues = dayRecords.compactMap(\.transcriptionTime).filter { $0 > 0 }
+            detailedWordsByDay[day] = words
+            output[day] = DailyTranscriptionSummary(
+                date: day,
+                words: words,
+                characters: characters,
+                sessions: dayRecords.count,
+                recordingDuration: recordingDuration,
+                processingDuration: processingValues.reduce(0, +),
+                processingSamples: processingValues.count
+            )
+        }
+
+        let recordWords = records.reduce(0) { $0 + wordCount(for: $1) }
+        let recordCharacters = records.reduce(0) { $0 + characterCount(for: $1) }
+        let recordDuration = records.reduce(0) { $0 + ($1.duration ?? 0) }
+        let processingValues = records.compactMap(\.transcriptionTime).filter { $0 > 0 }
+        let averageProcessingTime = processingValues.isEmpty
+            ? 0
+            : processingValues.reduce(0, +) / Double(processingValues.count)
+
+        let legacyTotalWords = max(0, snapshot.totalWords - recordWords)
+        let legacyTotalCharacters = max(0, snapshot.totalCharacters - recordCharacters)
+        let legacyTotalSessions = max(0, snapshot.totalSessions - records.count)
+        let legacyTotalDuration = max(0, snapshot.totalDuration - recordDuration)
+
+        for (day, words) in dailyWords(from: snapshot) {
+            let legacyWords = max(0, words - (detailedWordsByDay[day] ?? 0))
+            guard legacyWords > 0 else { continue }
+
+            let estimatedSessions = proportionalCount(
+                total: legacyTotalSessions,
+                value: legacyWords,
+                denominator: legacyTotalWords,
+                minimumWhenPositive: 1
+            )
+            let estimatedCharacters = proportionalCount(
+                total: legacyTotalCharacters,
+                value: legacyWords,
+                denominator: legacyTotalWords,
+                minimumWhenPositive: legacyWords
+            )
+            let estimatedRecordingDuration = proportionalDuration(
+                total: legacyTotalDuration,
+                value: legacyWords,
+                denominator: legacyTotalWords
+            )
+            let estimatedProcessingDuration = averageProcessingTime * Double(estimatedSessions)
+
+            let existing = output[day] ?? .empty(date: day)
+            output[day] = DailyTranscriptionSummary(
+                date: day,
+                words: existing.words + legacyWords,
+                characters: existing.characters + estimatedCharacters,
+                sessions: existing.sessions + estimatedSessions,
+                recordingDuration: existing.recordingDuration + estimatedRecordingDuration,
+                processingDuration: existing.processingDuration + estimatedProcessingDuration,
+                processingSamples: existing.processingSamples + (averageProcessingTime > 0 ? estimatedSessions : 0)
+            )
+        }
+
+        return output
+    }
+
+    func dailyWords(from snapshot: UsageSnapshot) -> [Date: Int] {
+        let formatter = Self.storageDayFormatter
+        var output: [Date: Int] = [:]
+        for (key, words) in snapshot.dailyActivity {
+            guard let date = formatter.date(from: key) else { continue }
+            let day = Calendar.current.startOfDay(for: date)
+            output[day] = words
+        }
+        return output
+    }
+
+    func proportionalCount(total: Int, value: Int, denominator: Int, minimumWhenPositive: Int) -> Int {
+        guard value > 0 else { return 0 }
+        guard total > 0, denominator > 0 else { return minimumWhenPositive }
+        let estimate = Int((Double(total) * Double(value) / Double(denominator)).rounded())
+        return max(minimumWhenPositive, estimate)
+    }
+
+    func proportionalDuration(total: TimeInterval, value: Int, denominator: Int) -> TimeInterval {
+        guard value > 0, total > 0, denominator > 0 else { return 0 }
+        return total * Double(value) / Double(denominator)
+    }
+
+    func makeAggregate(records: [TranscriptionRecord], summaries: [DailyTranscriptionSummary], snapshot: UsageSnapshot) -> DashboardAggregate {
+        let recordWords = records.reduce(0) { $0 + wordCount(for: $1) }
+        let recordCharacters = records.reduce(0) { $0 + characterCount(for: $1) }
+        let recordDuration = records.reduce(0) { $0 + ($1.duration ?? 0) }
+        let processingValues = records.compactMap(\.transcriptionTime).filter { $0 > 0 }
+        let hasUsageSnapshot = snapshot.totalSessions > 0 || snapshot.totalWords > 0 || !snapshot.dailyActivity.isEmpty
+
+        return DashboardAggregate(
+            words: hasUsageSnapshot ? max(snapshot.totalWords, recordWords) : recordWords,
+            characters: hasUsageSnapshot ? max(snapshot.totalCharacters, recordCharacters) : recordCharacters,
+            sessions: hasUsageSnapshot ? max(snapshot.totalSessions, records.count) : records.count,
+            activeDays: summaries.filter { $0.words > 0 }.count,
+            recordingDuration: hasUsageSnapshot ? max(snapshot.totalDuration, recordDuration) : recordDuration,
+            processingDuration: processingValues.reduce(0, +),
+            processingSamples: processingValues.count,
+            peakDailyWords: summaries.map(\.words).max() ?? 0
+        )
+    }
+
+    func makeBreakdown(records: [TranscriptionRecord], label: (TranscriptionRecord) -> String) -> [BreakdownRow] {
+        var buckets: [String: BreakdownRow] = [:]
+        for record in records {
+            let key = label(record)
+            let existing = buckets[key] ?? BreakdownRow(
+                label: key,
+                words: 0,
+                characters: 0,
+                sessions: 0,
+                recordingDuration: 0,
+                processingDuration: 0,
+                processingSamples: 0
+            )
+            let processing = record.transcriptionTime ?? 0
+            buckets[key] = BreakdownRow(
+                label: key,
+                words: existing.words + wordCount(for: record),
+                characters: existing.characters + characterCount(for: record),
+                sessions: existing.sessions + 1,
+                recordingDuration: existing.recordingDuration + (record.duration ?? 0),
+                processingDuration: existing.processingDuration + max(0, processing),
+                processingSamples: existing.processingSamples + (processing > 0 ? 1 : 0)
+            )
+        }
+
+        return buckets.values.sorted {
+            if $0.words == $1.words {
+                return $0.sessions > $1.sessions
+            }
+            return $0.words > $1.words
+        }
+    }
+
+    func makeBreakdown(sources: [SourceUsageStats]) -> [BreakdownRow] {
+        sources.map { source in
+            BreakdownRow(
+                label: source.displayName,
+                words: source.totalWords,
+                characters: source.totalCharacters,
+                sessions: source.sessionCount,
+                recordingDuration: 0,
+                processingDuration: 0,
+                processingSamples: 0
+            )
+        }
+    }
+
+    func rowsWithLegacySummary(_ rows: [BreakdownRow]) -> [BreakdownRow] {
+        let detailedWords = recentRecords.reduce(0) { $0 + wordCount(for: $1) }
+        let detailedCharacters = recentRecords.reduce(0) { $0 + characterCount(for: $1) }
+        let legacyWords = max(0, aggregate.words - detailedWords)
+        let legacyCharacters = max(0, aggregate.characters - detailedCharacters)
+        let legacySessions = max(0, aggregate.sessions - recentRecords.count)
+        let legacyProcessingDuration = aggregate.averageProcessingTime * Double(legacySessions)
+        guard legacyWords > 0 || legacySessions > 0 else {
+            return rows
+        }
+
+        return rows + [
+            legacyBreakdownRow(
+                words: legacyWords,
+                characters: legacyCharacters,
+                sessions: legacySessions,
+                recordingDuration: max(0, aggregate.recordingDuration - recentRecords.reduce(0) { $0 + ($1.duration ?? 0) }),
+                processingDuration: legacyProcessingDuration,
+                processingSamples: legacySessions
+            )
+        ]
+    }
+
+    func legacyBreakdownRow(
+        words: Int,
+        characters: Int,
+        sessions: Int,
+        recordingDuration: TimeInterval = 0,
+        processingDuration: TimeInterval = 0,
+        processingSamples: Int = 0
+    ) -> BreakdownRow {
+        BreakdownRow(
+            label: L10n.Home.legacySummary,
+            words: words,
+            characters: characters,
+            sessions: sessions,
+            recordingDuration: recordingDuration,
+            processingDuration: processingDuration,
+            processingSamples: processingSamples
+        )
     }
 
     func generateActivityWeeks() -> [[Date]] {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
+        let activeDates = dailySummaries.keys
+        let earliestDate = activeDates.min()
+        let minimumStartDate = calendar.date(
+            byAdding: .day,
+            value: -(Self.minimumActivityDays - 1),
+            to: today
+        ) ?? today
+        let startDate = min(earliestDate ?? minimumStartDate, minimumStartDate)
 
-        // Find the Saturday of the current week (end of week when Sunday = 1).
-        let todayWeekday = calendar.component(.weekday, from: today) // 1 = Sunday, 7 = Saturday
-        let daysUntilSaturday = 7 - todayWeekday
-        guard let currentWeekSaturday = calendar.date(byAdding: .day, value: daysUntilSaturday, to: today) else {
+        guard let firstWeekStart = startOfWeek(containing: startDate, calendar: calendar),
+              let lastWeekStart = startOfWeek(containing: today, calendar: calendar) else {
             return []
         }
 
         var weeks: [[Date]] = []
-
-        // Generate 4 weeks, most recent at bottom.
-        for weekOffset in (0..<4).reversed() {
+        var weekStart = firstWeekStart
+        while weekStart <= lastWeekStart {
             var week: [Date] = []
-            guard let weekSaturday = calendar.date(byAdding: .day, value: -weekOffset * 7, to: currentWeekSaturday) else {
-                continue
-            }
             for dayIndex in 0..<7 {
-                let daysFromSunday = dayIndex - 6 // Sunday is 6 days before Saturday
-                if let date = calendar.date(byAdding: .day, value: daysFromSunday, to: weekSaturday) {
-                    week.append(date)
+                if let date = calendar.date(byAdding: .day, value: dayIndex, to: weekStart) {
+                    week.append(calendar.startOfDay(for: date))
                 }
             }
             weeks.append(week)
-        }
 
+            guard let nextWeekStart = calendar.date(byAdding: .day, value: 7, to: weekStart) else {
+                break
+            }
+            weekStart = nextWeekStart
+        }
         return weeks
     }
 
-    func calculateStreak() -> Int {
+    func startOfWeek(containing date: Date, calendar: Calendar) -> Date? {
+        let day = calendar.startOfDay(for: date)
+        let daysFromSunday = calendar.component(.weekday, from: day) - 1
+        return calendar.date(byAdding: .day, value: -daysFromSunday, to: day)
+    }
+
+    func wordsInSelectedWeek() -> Int {
         let calendar = Calendar.current
-        var currentDate = Date()
-        var count = 0
-
-        while true {
-            let day = calendar.startOfDay(for: currentDate)
-            if let words = dailyActivity[day], words > 0 {
-                count += 1
-                guard let previousDay = calendar.date(byAdding: .day, value: -1, to: currentDate) else { break }
-                currentDate = previousDay
-            } else {
-                break
-            }
+        guard let weekStart = startOfWeek(containing: selectedDay, calendar: calendar),
+              let weekEnd = calendar.date(byAdding: .day, value: 7, to: weekStart) else {
+            return selectedSummary.words
         }
-
-        return count
+        return dailySummaries.values
+            .filter { $0.date >= weekStart && $0.date < weekEnd }
+            .reduce(0) { $0 + $1.words }
     }
 
-    func heatmapColor(for wordCount: Int) -> Color {
-        switch wordCount {
-        case 0:
-            return Color(nsColor: .quaternaryLabelColor).opacity(0.35)
-        case 1..<50:
-            return Color.accentColor.opacity(0.20)
-        case 50..<150:
-            return Color.accentColor.opacity(0.35)
-        case 150..<300:
-            return Color.accentColor.opacity(0.55)
-        default:
-            return Color.accentColor.opacity(0.80)
-        }
+    func providerLabel(for record: TranscriptionRecord) -> String {
+        L10n.Provider.displayName(for: record.provider)
     }
 
-    func heatmapTooltip(date: Date, words: Int) -> String {
-        "\(Self.heatmapDateFormatter.string(from: date)): \(words) words"
+    func modelLabel(for record: TranscriptionRecord) -> String {
+        if let model = record.modelUsed, !model.isEmpty {
+            return model
+        }
+        return providerLabel(for: record)
     }
 
-    func providerIcon(for provider: String) -> String {
-        switch provider.lowercased() {
-        case "openai":
-            return "cloud"
-        case "gemini":
-            return "sparkles"
-        case "local":
-            return "laptopcomputer"
-        case "parakeet":
-            return "bird"
-        default:
-            return "waveform"
-        }
+    func providerColor(for label: String) -> Color {
+        let lowered = label.lowercased()
+        if lowered.contains("openai") { return DashboardTheme.providerOpenAI }
+        if lowered.contains("gemini") { return DashboardTheme.providerGemini }
+        if lowered.contains("whisper") || lowered.contains("local") { return DashboardTheme.providerLocal }
+        if lowered.contains("parakeet") { return DashboardTheme.providerParakeet }
+        if lowered.contains("funasr") { return Color(nsColor: .systemOrange) }
+        return DashboardTheme.accent
     }
 
-    func providerDisplayName(for provider: String) -> String {
-        switch provider.lowercased() {
-        case "openai":
-            return "OpenAI"
-        case "gemini":
-            return "Gemini"
-        case "local":
-            return "Local Whisper"
-        case "parakeet":
-            return "Parakeet"
-        default:
-            return provider.capitalized
+    func sourceColor(for label: String) -> Color {
+        colorFromString(label, saturation: 0.60, brightness: 0.82)
+    }
+
+    func modelColor(for label: String) -> Color {
+        colorFromString(label, saturation: 0.55, brightness: 0.88)
+    }
+
+    func colorFromString(_ string: String, saturation: Double, brightness: Double) -> Color {
+        let scalars = string.unicodeScalars.reduce(UInt32(0)) { partial, scalar in
+            partial &+ scalar.value
         }
+        let hue = Double(scalars % 360) / 360.0
+        return Color(hue: hue, saturation: saturation, brightness: brightness)
+    }
+
+    func wordCount(for record: TranscriptionRecord) -> Int {
+        if record.wordCount > 0 {
+            return record.wordCount
+        }
+        return UsageMetricsStore.estimatedWordCount(for: record.text)
+    }
+
+    func characterCount(for record: TranscriptionRecord) -> Int {
+        if record.characterCount > 0 {
+            return record.characterCount
+        }
+        return record.text.count
     }
 
     func formatNumber(_ value: Int) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+        Self.integerFormatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    func formatCompactNumber(_ value: Int) -> String {
+        if L10n.isChinese {
+            if value >= 100_000_000 {
+                return String(format: "%.2f亿", Double(value) / 100_000_000)
+            }
+            if value >= 10_000 {
+                return String(format: "%.1f万", Double(value) / 10_000)
+            }
+            return formatNumber(value)
+        }
+        if value >= 1_000_000 {
+            return String(format: "%.1fM", Double(value) / 1_000_000)
+        }
+        if value >= 10_000 {
+            return String(format: "%.1fK", Double(value) / 1_000)
+        }
+        return formatNumber(value)
     }
 
     func formatDecimal(_ value: Double) -> String {
@@ -380,35 +1723,78 @@ private extension DashboardHomeView {
     }
 
     func formatDuration(_ interval: TimeInterval) -> String {
-        guard interval > 0 else { return "0m" }
-        let totalSeconds = Int(interval)
-        let hours = totalSeconds / 3600
-        let minutes = (totalSeconds % 3600) / 60
+        L10n.Format.duration(interval)
+    }
 
-        if hours > 0 {
-            return "\(hours)h \(minutes)m"
+    func formatDurationShort(_ interval: TimeInterval) -> String {
+        guard interval > 0 else { return "0" }
+        if interval < 60 {
+            return String(format: "%.0fs", interval)
         }
-        return "\(minutes)m"
+        if interval < 3600 {
+            return "\(Int(interval / 60))m"
+        }
+        return "\(Int(interval / 3600))h"
     }
 
-    func formatTime(_ date: Date) -> String {
-        Self.timeFormatter.string(from: date)
+    func formatDurationPrecise(_ interval: TimeInterval) -> String {
+        guard interval > 0 else { return "0" }
+        if interval < 1 {
+            return String(format: "%.0fms", interval * 1000)
+        }
+        if interval < 60 {
+            return String(format: "%.1fs", interval)
+        }
+        let minutes = Int(interval / 60)
+        let seconds = Int(interval.truncatingRemainder(dividingBy: 60))
+        if minutes < 60 {
+            return "\(minutes)m \(seconds)s"
+        }
+        let hours = minutes / 60
+        return "\(hours)h \(minutes % 60)m"
     }
 
-    private static let heatmapDateFormatter: DateFormatter = {
+    private static let integerFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 0
+        return formatter
+    }()
+
+    private static let storageDayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    private static let dayTitleFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    private static let shortDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("M/d")
+        return formatter
+    }()
+
+    private static let trendTooltipFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
+        formatter.timeStyle = .none
         return formatter
     }()
 
     private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "h:mm a"
+        formatter.dateFormat = "H:mm"
         return formatter
     }()
 }
 
 #Preview("Dashboard Home") {
     DashboardHomeView(selectedNav: .constant(.dashboard))
-        .frame(width: 900, height: 700)
+        .frame(width: 1080, height: 760)
 }

--- a/Sources/Views/Dashboard/DashboardPreferencesView.swift
+++ b/Sources/Views/Dashboard/DashboardPreferencesView.swift
@@ -8,28 +8,46 @@ internal struct DashboardPreferencesView: View {
     @AppStorage("autoBoostMicrophoneVolume") private var autoBoostMicrophoneVolume = false
     @AppStorage("enableSmartPaste") private var enableSmartPaste = false
     @AppStorage("playCompletionSound") private var playCompletionSound = true
-    @AppStorage("transcriptionHistoryEnabled") private var transcriptionHistoryEnabled = false
-    @AppStorage("transcriptionRetentionPeriod") private var transcriptionRetentionPeriodRaw = RetentionPeriod.oneMonth.rawValue
+    @AppStorage("transcriptionHistoryEnabled") private var transcriptionHistoryEnabled = true
+    @AppStorage("transcriptionRetentionPeriod") private var transcriptionRetentionPeriodRaw = RetentionPeriod.forever.rawValue
     @AppStorage("maxModelStorageGB") private var maxModelStorageGB = 5.0
 
+    @ObservedObject private var languageManager = LanguageManager.shared
     @State private var loginItemError: String?
 
     private let storageOptions: [Double] = [1, 2, 5, 10, 20]
 
     private var retentionBinding: Binding<RetentionPeriod> {
         Binding(
-            get: { RetentionPeriod(rawValue: transcriptionRetentionPeriodRaw) ?? .oneMonth },
+            get: { RetentionPeriod(rawValue: transcriptionRetentionPeriodRaw) ?? .forever },
             set: { transcriptionRetentionPeriodRaw = $0.rawValue }
         )
     }
 
     var body: some View {
         Form {
-            Section("General") {
+            // Language setting at the top
+            Section {
+                Picker(L10n.Preferences.language, selection: $languageManager.current) {
+                    ForEach(AppLanguage.allCases) { lang in
+                        Text(lang.displayName).tag(lang)
+                    }
+                }
+                .pickerStyle(.menu)
+                .onChange(of: languageManager.current) { _, _ in
+                    (NSApp.delegate as? AppDelegate)?.refreshStatusMenu()
+                }
+            } header: {
+                Text(L10n.Preferences.language)
+            } footer: {
+                Text(L10n.Preferences.languageFooter)
+            }
+
+            Section(L10n.Preferences.general) {
                 Toggle(isOn: $startAtLogin) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Start at Login")
-                        Text("Launch AudioWhisper when you sign in.")
+                        Text(L10n.Preferences.startAtLogin)
+                        Text(L10n.Preferences.startAtLoginDesc)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -40,8 +58,8 @@ internal struct DashboardPreferencesView: View {
 
                 Toggle(isOn: $immediateRecording) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Express Mode")
-                        Text("Hotkey immediately starts and stops recording.")
+                        Text(L10n.Preferences.expressMode)
+                        Text(L10n.Preferences.expressModeDesc)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -49,8 +67,8 @@ internal struct DashboardPreferencesView: View {
 
                 Toggle(isOn: $autoBoostMicrophoneVolume) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Auto-Boost Microphone")
-                        Text("Temporarily maximize mic input while recording.")
+                        Text(L10n.Preferences.autoBoost)
+                        Text(L10n.Preferences.autoBoostDesc)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -58,8 +76,8 @@ internal struct DashboardPreferencesView: View {
 
                 Toggle(isOn: $enableSmartPaste) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Smart Paste")
-                        Text("Automatically paste finished transcripts.")
+                        Text(L10n.Preferences.smartPaste)
+                        Text(L10n.Preferences.smartPasteDesc)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -67,8 +85,8 @@ internal struct DashboardPreferencesView: View {
 
                 Toggle(isOn: $playCompletionSound) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Completion Sound")
-                        Text("Play a chime when transcription finishes.")
+                        Text(L10n.Preferences.completionSound)
+                        Text(L10n.Preferences.completionSoundDesc)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -83,8 +101,8 @@ internal struct DashboardPreferencesView: View {
             Section {
                 Toggle(isOn: $transcriptionHistoryEnabled) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Save Transcription History")
-                        Text("Store transcripts locally so you can search and review them later.")
+                        Text(L10n.Preferences.saveHistory)
+                        Text(L10n.Preferences.saveHistoryDesc)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -99,13 +117,11 @@ internal struct DashboardPreferencesView: View {
                     .pickerStyle(.menu)
                 }
             } header: {
-                Text("History")
-            } footer: {
-                Text("View saved transcripts in the Transcripts section in the sidebar.")
+                Text(L10n.Preferences.history)
             }
 
-            Section("Storage") {
-                Picker("Max Model Storage", selection: $maxModelStorageGB) {
+            Section(L10n.Preferences.storage) {
+                Picker(L10n.Preferences.maxModelStorage, selection: $maxModelStorageGB) {
                     ForEach(storageOptions, id: \.self) { option in
                         Text("\(Int(option)) GB").tag(option)
                     }
@@ -113,8 +129,8 @@ internal struct DashboardPreferencesView: View {
                 .pickerStyle(.menu)
             }
 
-            Section("About") {
-                LabeledContent("Version") {
+            Section(L10n.Preferences.about) {
+                LabeledContent(L10n.Preferences.version) {
                     Text(VersionInfo.fullVersionInfo)
                         .font(.system(.body, design: .monospaced))
                         .foregroundStyle(.secondary)

--- a/Sources/Views/Dashboard/DashboardTimingAnalysisView.swift
+++ b/Sources/Views/Dashboard/DashboardTimingAnalysisView.swift
@@ -1,0 +1,715 @@
+import SwiftUI
+import Charts
+
+private enum TimingStage: String, CaseIterable, Identifiable {
+    case recording
+    case modelReady
+    case asr
+    case correction
+    case legacyProcessing
+    case untrackedProcessing
+    case clipboard
+    case paste
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .recording: return L10n.Timing.recording
+        case .modelReady: return L10n.Timing.modelReady
+        case .asr: return L10n.Timing.asr
+        case .correction: return L10n.Timing.correction
+        case .legacyProcessing: return L10n.Timing.legacyProcessing
+        case .untrackedProcessing: return L10n.Timing.untrackedProcessing
+        case .clipboard: return L10n.Timing.clipboard
+        case .paste: return L10n.Timing.paste
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .recording: return Color(nsColor: .systemCyan)
+        case .modelReady: return Color(nsColor: .systemIndigo)
+        case .asr: return DashboardTheme.success
+        case .correction: return Color(nsColor: .systemPurple)
+        case .legacyProcessing: return Color(nsColor: .systemOrange)
+        case .untrackedProcessing: return Color(nsColor: .systemYellow)
+        case .clipboard: return DashboardTheme.accent
+        case .paste: return Color(nsColor: .systemRed)
+        }
+    }
+}
+
+private struct TimingSegment: Identifiable {
+    let id: String
+    let recordID: UUID
+    let chartKey: String
+    let runLabel: String
+    let stage: TimingStage
+    let seconds: TimeInterval
+}
+
+private struct TimingRun: Identifiable {
+    let record: TranscriptionRecord
+    let index: Int
+
+    var id: UUID { record.id }
+
+    var runLabel: String {
+        "\(index + 1). \(Self.shortFormatter.string(from: record.date))"
+    }
+
+    var chartKey: String {
+        String(format: "%05d", index + 1)
+    }
+
+    var chartLabel: String {
+        "\(index + 1)"
+    }
+
+    var detailLine: String {
+        let provider = L10n.Provider.displayName(for: record.provider)
+        let source = record.sourceAppName?.isEmpty == false ? record.sourceAppName! : "-"
+        return "\(provider) · \(source)"
+    }
+
+    func segments(includeRecording: Bool) -> [TimingSegment] {
+        var output: [TimingSegment] = []
+
+        if includeRecording, let duration = record.duration, duration > 0 {
+            output.append(segment(.recording, duration))
+        }
+
+        if record.hasDetailedTiming {
+            appendPositive(record.modelReadyTime, stage: .modelReady, to: &output)
+            appendPositive(record.asrTime, stage: .asr, to: &output)
+            appendPositive(record.correctionTime, stage: .correction, to: &output)
+
+            let knownProcessing = [record.modelReadyTime, record.asrTime, record.correctionTime]
+                .compactMap { $0 }
+                .reduce(0, +)
+            if let total = record.transcriptionTime {
+                let remaining = max(0, total - knownProcessing)
+                appendPositive(remaining > 0.05 ? remaining : nil, stage: .untrackedProcessing, to: &output)
+            }
+
+            appendPositive(record.clipboardTime, stage: .clipboard, to: &output)
+            appendPositive(record.pasteTime, stage: .paste, to: &output)
+        } else if let total = record.transcriptionTime, total > 0 {
+            output.append(segment(.legacyProcessing, total))
+        }
+
+        return output
+    }
+
+    func visibleTotal(includeRecording: Bool) -> TimeInterval {
+        segments(includeRecording: includeRecording).reduce(0) { $0 + $1.seconds }
+    }
+
+    func processingTotal() -> TimeInterval {
+        segments(includeRecording: false).reduce(0) { $0 + $1.seconds }
+    }
+
+    private func appendPositive(_ value: TimeInterval?, stage: TimingStage, to output: inout [TimingSegment]) {
+        guard let value, value > 0 else { return }
+        output.append(segment(stage, value))
+    }
+
+    private func segment(_ stage: TimingStage, _ seconds: TimeInterval) -> TimingSegment {
+        TimingSegment(
+            id: "\(record.id.uuidString)-\(stage.rawValue)",
+            recordID: record.id,
+            chartKey: chartKey,
+            runLabel: runLabel,
+            stage: stage,
+            seconds: seconds
+        )
+    }
+
+    private static let shortFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("M/d HH:mm")
+        return formatter
+    }()
+}
+
+internal struct DashboardTimingAnalysisView: View {
+    @ObservedObject private var languageManager = LanguageManager.shared
+    @State private var records: [TranscriptionRecord] = []
+    @State private var includeRecording = false
+    @State private var recordLimit = 50
+    @State private var hoveredRunID: UUID?
+    @State private var timingHoverLocation: CGPoint?
+
+    private var runs: [TimingRun] {
+        let source = recordLimit == 0 ? records : Array(records.prefix(recordLimit))
+        return source.enumerated()
+            .map { TimingRun(record: $0.element, index: $0.offset) }
+            .filter { !$0.segments(includeRecording: true).isEmpty }
+    }
+
+    private var visibleRuns: [TimingRun] {
+        runs.filter { !$0.segments(includeRecording: includeRecording).isEmpty }
+    }
+
+    private var chartSegments: [TimingSegment] {
+        visibleRuns.flatMap { $0.segments(includeRecording: includeRecording) }
+    }
+
+    private var hoveredRun: TimingRun? {
+        guard let hoveredRunID else { return nil }
+        return visibleRuns.first { $0.id == hoveredRunID }
+    }
+
+    private var chartWidth: CGFloat {
+        max(900, CGFloat(visibleRuns.count) * 36)
+    }
+
+    private var chartYUpperBound: Double {
+        let maxTotal = visibleRuns
+            .map { $0.visibleTotal(includeRecording: includeRecording) }
+            .max() ?? 0
+        return max(1, maxTotal * 1.16)
+    }
+
+    private var xAxisVisibleKeys: [String] {
+        guard !visibleRuns.isEmpty else { return [] }
+        let maxLabels = 18
+        let interval = max(1, Int(ceil(Double(visibleRuns.count) / Double(maxLabels))))
+
+        return visibleRuns.enumerated().compactMap { offset, run in
+            if offset == 0 || offset == visibleRuns.count - 1 || offset % interval == 0 {
+                return run.chartKey
+            }
+            return nil
+        }
+    }
+
+    private var stageTotals: [(stage: TimingStage, seconds: TimeInterval)] {
+        TimingStage.allCases.compactMap { stage in
+            let total = chartSegments
+                .filter { $0.stage == stage }
+                .reduce(0) { $0 + $1.seconds }
+            return total > 0 ? (stage, total) : nil
+        }
+        .sorted { $0.seconds > $1.seconds }
+    }
+
+    private var averageProcessing: TimeInterval {
+        guard !runs.isEmpty else { return 0 }
+        return runs.reduce(0) { $0 + $1.processingTotal() } / Double(runs.count)
+    }
+
+    private var slowestRun: TimingRun? {
+        visibleRuns.max { $0.visibleTotal(includeRecording: includeRecording) < $1.visibleTotal(includeRecording: includeRecording) }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                header
+                controls
+                summaryGrid
+                breakdownChart
+                stageDistribution
+                detailRows
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(DashboardTheme.pageBg)
+        .id(languageManager.current)
+        .task {
+            await loadRecords()
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(L10n.Timing.title)
+                .font(.system(size: 34, weight: .bold))
+                .foregroundStyle(DashboardTheme.ink)
+
+            Text(L10n.Timing.subtitle)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(DashboardTheme.inkLight)
+        }
+    }
+
+    private var controls: some View {
+        TimingPanel {
+            HStack(spacing: 18) {
+                Toggle(L10n.Timing.includeRecording, isOn: $includeRecording)
+                    .toggleStyle(.switch)
+                    .tint(DashboardTheme.accent)
+
+                Spacer()
+
+                Picker(L10n.Timing.recordLimit, selection: $recordLimit) {
+                    Text(L10n.Timing.latestRecords(20)).tag(20)
+                    Text(L10n.Timing.latestRecords(50)).tag(50)
+                    Text(L10n.Timing.latestRecords(100)).tag(100)
+                    Text(L10n.Timing.allRecords).tag(0)
+                }
+                .frame(width: 180)
+            }
+        }
+    }
+
+    private var summaryGrid: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 180), spacing: 12)], spacing: 12) {
+            TimingStatTile(title: L10n.Timing.analyzedRuns, value: "\(visibleRuns.count)", tint: DashboardTheme.accent)
+            TimingStatTile(title: L10n.Timing.averageProcessing, value: formatDuration(averageProcessing), tint: DashboardTheme.success)
+            TimingStatTile(title: L10n.Timing.slowestRun, value: slowestRun.map { formatDuration($0.visibleTotal(includeRecording: includeRecording)) } ?? "0s", tint: Color(nsColor: .systemRed))
+            TimingStatTile(title: L10n.Timing.slowestStage, value: stageTotals.first.map { $0.stage.title } ?? "-", tint: stageTotals.first?.stage.color ?? DashboardTheme.inkMuted)
+        }
+    }
+
+    private var breakdownChart: some View {
+        TimingPanel {
+            VStack(alignment: .leading, spacing: 14) {
+                Text(L10n.Timing.runBreakdown)
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(DashboardTheme.ink)
+
+                if chartSegments.isEmpty {
+                    emptyState
+                } else {
+                    ScrollView(.horizontal, showsIndicators: true) {
+                        Chart {
+                            ForEach(chartSegments) { segment in
+                                BarMark(
+                                    x: .value(L10n.Timing.recordDetails, segment.chartKey),
+                                    y: .value(L10n.Timing.total, segment.seconds)
+                                )
+                                .foregroundStyle(by: .value(L10n.Timing.stageDistribution, segment.stage.title))
+                                .cornerRadius(3)
+                            }
+
+                            if let hoveredRun {
+                                RuleMark(x: .value(L10n.Timing.recordDetails, hoveredRun.chartKey))
+                                    .foregroundStyle(DashboardTheme.inkMuted.opacity(0.55))
+                                    .lineStyle(.init(lineWidth: 1, dash: [4, 4]))
+                            }
+                        }
+                        .chartForegroundStyleScale(stageColorScale)
+                        .chartYScale(domain: 0...chartYUpperBound)
+                        .chartLegend(.hidden)
+                        .chartXAxis {
+                            AxisMarks(values: xAxisVisibleKeys) { value in
+                                AxisGridLine()
+                                    .foregroundStyle(DashboardTheme.rule.opacity(0.42))
+                                AxisTick()
+                                    .foregroundStyle(DashboardTheme.inkMuted.opacity(0.75))
+                                AxisValueLabel {
+                                    if let key = value.as(String.self) {
+                                        Text(chartLabel(for: key))
+                                            .font(.caption2.weight(.semibold))
+                                            .foregroundStyle(DashboardTheme.inkLight)
+                                    }
+                                }
+                            }
+                        }
+                        .chartYAxis {
+                            AxisMarks(position: .leading, values: .automatic(desiredCount: 5)) { value in
+                                AxisGridLine()
+                                    .foregroundStyle(DashboardTheme.rule.opacity(0.55))
+                                AxisValueLabel {
+                                    if let seconds = value.as(Double.self) {
+                                        Text(formatDuration(seconds))
+                                            .font(.caption2.monospacedDigit().weight(.semibold))
+                                            .foregroundStyle(DashboardTheme.inkLight)
+                                    }
+                                }
+                            }
+                        }
+                        .chartPlotStyle { plotArea in
+                            plotArea
+                                .padding(.leading, 8)
+                                .padding(.bottom, 4)
+                        }
+                        .chartOverlay { proxy in
+                            GeometryReader { geometry in
+                                Rectangle()
+                                    .fill(.clear)
+                                    .contentShape(Rectangle())
+                                    .onContinuousHover { phase in
+                                        updateRunHover(phase: phase, proxy: proxy, geometry: geometry)
+                                    }
+                            }
+                        }
+                        .overlay {
+                            GeometryReader { geometry in
+                                if let hoveredRun, let timingHoverLocation {
+                                    let x = min(
+                                        max(timingHoverLocation.x + 124, 124),
+                                        max(124, geometry.size.width - 124)
+                                    )
+                                    let y = min(
+                                        max(timingHoverLocation.y - 112, 106),
+                                        max(106, geometry.size.height - 106)
+                                    )
+
+                                    TimingRunHoverTooltip(
+                                        run: hoveredRun,
+                                        includeRecording: includeRecording,
+                                        millisecondFormatter: formatMilliseconds
+                                    )
+                                    .position(x: x, y: y)
+                                }
+                            }
+                            .allowsHitTesting(false)
+                        }
+                        .frame(width: chartWidth, height: 340)
+                    }
+                    .frame(height: 370)
+                }
+            }
+        }
+    }
+
+    private var stageDistribution: some View {
+        TimingPanel {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(L10n.Timing.stageDistribution)
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(DashboardTheme.ink)
+
+                if stageTotals.isEmpty {
+                    emptyState
+                } else {
+                    VStack(spacing: 10) {
+                        ForEach(Array(stageTotals.enumerated()), id: \.element.stage.id) { _, item in
+                            TimingStageRow(
+                                stage: item.stage,
+                                seconds: item.seconds,
+                                total: stageTotals.reduce(0) { $0 + $1.seconds },
+                                formatter: formatDuration
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var detailRows: some View {
+        TimingPanel {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(L10n.Timing.recordDetails)
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(DashboardTheme.ink)
+
+                if visibleRuns.isEmpty {
+                    emptyState
+                } else {
+                    VStack(spacing: 0) {
+                        ForEach(visibleRuns) { run in
+                            TimingDetailRow(
+                                run: run,
+                                includeRecording: includeRecording,
+                                durationFormatter: formatDuration
+                            )
+                            if run.id != visibleRuns.last?.id {
+                                Divider()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(L10n.Timing.noTimingData)
+                .font(.headline)
+            Text(L10n.Timing.noTimingDataHint)
+                .font(.subheadline)
+                .foregroundStyle(DashboardTheme.inkMuted)
+        }
+        .frame(maxWidth: .infinity, minHeight: 120, alignment: .center)
+    }
+
+    private var stageColorScale: KeyValuePairs<String, Color> {
+        [
+            L10n.Timing.recording: Color(nsColor: .systemCyan),
+            L10n.Timing.modelReady: Color(nsColor: .systemIndigo),
+            L10n.Timing.asr: DashboardTheme.success,
+            L10n.Timing.correction: Color(nsColor: .systemPurple),
+            L10n.Timing.legacyProcessing: Color(nsColor: .systemOrange),
+            L10n.Timing.untrackedProcessing: Color(nsColor: .systemYellow),
+            L10n.Timing.clipboard: DashboardTheme.accent,
+            L10n.Timing.paste: Color(nsColor: .systemRed)
+        ]
+    }
+
+    @MainActor
+    private func loadRecords() async {
+        records = await DataManager.shared.fetchAllRecordsQuietly()
+    }
+
+    private func formatDuration(_ seconds: TimeInterval) -> String {
+        guard seconds.isFinite, seconds > 0 else { return "0s" }
+        if seconds < 1 {
+            return String(format: "%.0fms", seconds * 1000)
+        }
+        if seconds < 60 {
+            return String(format: "%.1fs", seconds)
+        }
+        let minutes = Int(seconds / 60)
+        let remainder = Int(seconds.truncatingRemainder(dividingBy: 60))
+        if minutes < 60 {
+            return "\(minutes)m \(remainder)s"
+        }
+        return "\(minutes / 60)h \(minutes % 60)m"
+    }
+
+    private func formatMilliseconds(_ seconds: TimeInterval) -> String {
+        guard seconds.isFinite, seconds > 0 else { return "0 ms" }
+        let milliseconds = max(1, Int((seconds * 1000).rounded()))
+        let formatted = Self.integerFormatter.string(from: NSNumber(value: milliseconds)) ?? "\(milliseconds)"
+        return "\(formatted) ms"
+    }
+
+    private func chartLabel(for key: String) -> String {
+        visibleRuns.first { $0.chartKey == key }?.chartLabel ?? key
+    }
+
+    private func updateRunHover(phase: HoverPhase, proxy: ChartProxy, geometry: GeometryProxy) {
+        switch phase {
+        case .active(let location):
+            guard let plotFrameAnchor = proxy.plotFrame else {
+                hoveredRunID = nil
+                timingHoverLocation = nil
+                return
+            }
+
+            let plotFrame = geometry[plotFrameAnchor]
+            guard plotFrame.contains(location) else {
+                hoveredRunID = nil
+                timingHoverLocation = nil
+                return
+            }
+
+            let x = location.x - plotFrame.origin.x
+            guard let key: String = proxy.value(atX: x),
+                  let run = visibleRuns.first(where: { $0.chartKey == key }) else {
+                hoveredRunID = nil
+                timingHoverLocation = nil
+                return
+            }
+
+            hoveredRunID = run.id
+            timingHoverLocation = location
+        case .ended:
+            hoveredRunID = nil
+            timingHoverLocation = nil
+        }
+    }
+
+    private static let integerFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 0
+        return formatter
+    }()
+}
+
+private struct TimingPanel<Content: View>: View {
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            content
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DashboardTheme.cardBg, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(DashboardTheme.rule.opacity(0.75), lineWidth: 1)
+        )
+    }
+}
+
+private struct TimingStatTile: View {
+    let title: String
+    let value: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(DashboardTheme.inkMuted)
+            Text(value)
+                .font(.system(size: 24, weight: .heavy, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(tint)
+                .lineLimit(2)
+                .minimumScaleFactor(0.55)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, minHeight: 98, alignment: .leading)
+        .background(DashboardTheme.cardBgAlt, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(DashboardTheme.rule.opacity(0.55), lineWidth: 1)
+        )
+    }
+}
+
+private struct TimingStageRow: View {
+    let stage: TimingStage
+    let seconds: TimeInterval
+    let total: TimeInterval
+    let formatter: (TimeInterval) -> String
+
+    private var share: Double {
+        guard total > 0 else { return 0 }
+        return seconds / total
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Circle()
+                    .fill(stage.color)
+                    .frame(width: 8, height: 8)
+                Text(stage.title)
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Text("\(formatter(seconds)) · \(String(format: "%.0f%%", share * 100))")
+                    .font(.subheadline.weight(.bold))
+                    .monospacedDigit()
+                    .foregroundStyle(stage.color)
+            }
+
+            GeometryReader { proxy in
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(stage.color.opacity(0.82))
+                    .frame(width: max(4, proxy.size.width * share))
+            }
+            .frame(height: 6)
+            .background(DashboardTheme.inkFaint.opacity(0.16), in: RoundedRectangle(cornerRadius: 3))
+        }
+    }
+}
+
+private struct TimingRunHoverTooltip: View {
+    let run: TimingRun
+    let includeRecording: Bool
+    let millisecondFormatter: (TimeInterval) -> String
+
+    private var segments: [TimingSegment] {
+        run.segments(includeRecording: includeRecording)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 8) {
+                Text("#\(run.chartLabel)")
+                    .font(.caption.weight(.heavy))
+                    .foregroundStyle(DashboardTheme.accent)
+                Text(run.runLabel)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(DashboardTheme.ink)
+            }
+
+            Text(run.detailLine)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(DashboardTheme.inkMuted)
+                .lineLimit(1)
+
+            Text("\(L10n.Timing.total) \(millisecondFormatter(run.visibleTotal(includeRecording: includeRecording)))")
+                .font(.caption.monospacedDigit().weight(.semibold))
+                .foregroundStyle(DashboardTheme.inkLight)
+
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(segments) { segment in
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(segment.stage.color)
+                            .frame(width: 6, height: 6)
+                        Text(segment.stage.title)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(DashboardTheme.inkMuted)
+                        Spacer(minLength: 12)
+                        Text(millisecondFormatter(segment.seconds))
+                            .font(.caption2.monospacedDigit().weight(.bold))
+                            .foregroundStyle(segment.stage.color)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 9)
+        .padding(.horizontal, 10)
+        .frame(width: 236, alignment: .leading)
+        .background(DashboardTheme.cardBgAlt, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(DashboardTheme.rule.opacity(0.8), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.25), radius: 10, x: 0, y: 6)
+    }
+}
+
+private struct TimingDetailRow: View {
+    let run: TimingRun
+    let includeRecording: Bool
+    let durationFormatter: (TimeInterval) -> String
+
+    private var segments: [TimingSegment] {
+        run.segments(includeRecording: includeRecording)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(run.runLabel)
+                        .font(.headline)
+                        .foregroundStyle(DashboardTheme.ink)
+                    Text(run.detailLine)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(DashboardTheme.inkMuted)
+                }
+
+                Spacer()
+
+                Text(durationFormatter(run.visibleTotal(includeRecording: includeRecording)))
+                    .font(.headline.monospacedDigit())
+                    .foregroundStyle(DashboardTheme.ink)
+            }
+
+            HStack(spacing: 8) {
+                ForEach(segments) { segment in
+                    Label {
+                        Text("\(segment.stage.title) \(durationFormatter(segment.seconds))")
+                    } icon: {
+                        Circle()
+                            .fill(segment.stage.color)
+                            .frame(width: 7, height: 7)
+                    }
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(DashboardTheme.inkLight)
+                }
+            }
+            .lineLimit(2)
+
+            if !run.record.hasDetailedTiming, run.record.transcriptionTime != nil {
+                Text(L10n.Timing.oldRecordHint)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(DashboardTheme.inkMuted)
+            }
+        }
+        .padding(.vertical, 12)
+    }
+}
+
+#Preview("Timing Analysis") {
+    DashboardTimingAnalysisView()
+        .frame(width: 1100, height: 760)
+}

--- a/Sources/Views/Dashboard/DashboardView.swift
+++ b/Sources/Views/Dashboard/DashboardView.swift
@@ -78,19 +78,34 @@ internal enum DashboardTheme {
 
 // MARK: - Navigation Item
 internal enum DashboardNavItem: String, CaseIterable, Identifiable, Hashable {
-    case dashboard = "Overview"
-    case transcripts = "Transcripts"
-    case categories = "Categories"
-    case recording = "Recording"
-    case providers = "Providers"
-    case preferences = "Preferences"
-    case permissions = "Permissions"
+    case dashboard
+    case timingAnalysis
+    case transcripts
+    case categories
+    case recording
+    case providers
+    case preferences
+    case permissions
 
     var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .dashboard: return L10n.Nav.overview
+        case .timingAnalysis: return L10n.Nav.timingAnalysis
+        case .transcripts: return L10n.Nav.transcripts
+        case .categories: return L10n.Nav.categories
+        case .recording: return L10n.Nav.recording
+        case .providers: return L10n.Nav.providers
+        case .preferences: return L10n.Nav.preferences
+        case .permissions: return L10n.Nav.permissions
+        }
+    }
 
     var icon: String {
         switch self {
         case .dashboard: return "square.text.square"
+        case .timingAnalysis: return "chart.bar.xaxis"
         case .transcripts: return "doc.text"
         case .categories: return "folder"
         case .recording: return "waveform"
@@ -109,24 +124,26 @@ internal struct DashboardView: View {
         self.selectionModel = selectionModel
     }
 
+    @ObservedObject private var languageManager = LanguageManager.shared
+
     var body: some View {
         NavigationSplitView {
             List(DashboardNavItem.allCases, selection: $selectionModel.selectedNav) { item in
-                Label(item.rawValue, systemImage: item.icon)
+                Label(item.displayName, systemImage: item.icon)
                     .tag(item)
             }
             .listStyle(.sidebar)
-            // Remove the built-in sidebar toggle to keep the titlebar clean.
             .toolbar(removing: .sidebarToggle)
         } detail: {
             if let selectedNav = selectionModel.selectedNav {
                 detailView(for: selectedNav)
-                    .navigationTitle(selectedNav.rawValue)
+                    .navigationTitle(selectedNav.displayName)
             } else {
-                Text("Select a section in the sidebar")
+                Text(L10n.Nav.selectSection)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
+        .id(languageManager.current)
     }
 
     @ViewBuilder
@@ -134,6 +151,8 @@ internal struct DashboardView: View {
         switch item {
         case .dashboard:
             DashboardHomeView(selectedNav: Binding(get: { selectionModel.selectedNav ?? .dashboard }, set: { selectionModel.selectedNav = $0 }))
+        case .timingAnalysis:
+            DashboardTimingAnalysisView()
         case .transcripts:
             DashboardTranscriptsView()
         case .categories:

--- a/Tests/AppDefaultsTests.swift
+++ b/Tests/AppDefaultsTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import AudioWhisper
+
+final class AppDefaultsTests: XCTestCase {
+    private var defaultsSuiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        defaultsSuiteName = "com.audiowhisper.tests.appdefaults.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        defaults = nil
+        defaultsSuiteName = nil
+        super.tearDown()
+    }
+
+    func testMigrateHistoryPreferencesCopiesProductionSettingsForDevBuild() {
+        defaults.set(true, forKey: AppDefaults.Keys.transcriptionHistoryEnabled, inDomain: "com.audiowhisper.app")
+        defaults.set(RetentionPeriod.threeMonths.rawValue, forKey: AppDefaults.Keys.transcriptionRetentionPeriod, inDomain: "com.audiowhisper.app")
+
+        AppDefaults.migrateHistoryPreferencesIfNeeded(
+            currentBundleIdentifier: "com.audiowhisper-dev.app",
+            userDefaults: defaults
+        )
+
+        XCTAssertEqual(defaults.object(forKey: AppDefaults.Keys.transcriptionHistoryEnabled) as? Bool, true)
+        XCTAssertEqual(defaults.string(forKey: AppDefaults.Keys.transcriptionRetentionPeriod), RetentionPeriod.threeMonths.rawValue)
+    }
+
+    func testMigrateHistoryPreferencesDoesNotOverrideExistingDevSettings() {
+        defaults.set(false, forKey: AppDefaults.Keys.transcriptionHistoryEnabled)
+        defaults.set(RetentionPeriod.forever.rawValue, forKey: AppDefaults.Keys.transcriptionRetentionPeriod)
+        defaults.set(true, forKey: AppDefaults.Keys.transcriptionHistoryEnabled, inDomain: "com.audiowhisper.app")
+        defaults.set(RetentionPeriod.oneWeek.rawValue, forKey: AppDefaults.Keys.transcriptionRetentionPeriod, inDomain: "com.audiowhisper.app")
+
+        AppDefaults.migrateHistoryPreferencesIfNeeded(
+            currentBundleIdentifier: "com.audiowhisper-dev.app",
+            userDefaults: defaults
+        )
+
+        XCTAssertEqual(defaults.object(forKey: AppDefaults.Keys.transcriptionHistoryEnabled) as? Bool, false)
+        XCTAssertEqual(defaults.string(forKey: AppDefaults.Keys.transcriptionRetentionPeriod), RetentionPeriod.forever.rawValue)
+    }
+}
+
+private extension UserDefaults {
+    func set(_ value: Any, forKey key: String, inDomain domainName: String) {
+        var domain = persistentDomain(forName: domainName) ?? [:]
+        domain[key] = value
+        setPersistentDomain(domain, forName: domainName)
+    }
+}

--- a/Tests/AppDelegateMenuTests.swift
+++ b/Tests/AppDelegateMenuTests.swift
@@ -1,0 +1,38 @@
+import AppKit
+import XCTest
+@testable import AudioWhisper
+
+final class AppDelegateMenuTests: XCTestCase {
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "appLanguage")
+        super.tearDown()
+    }
+
+    @MainActor
+    func testStatusMenuVisibleItemsAreOrderedForChinese() {
+        LanguageManager.shared.current = .chinese
+
+        let titles = visibleMenuTitles(from: AppDelegate().makeStatusMenu())
+
+        XCTAssertEqual(titles, ["录音", "转录音频文件...", "设置", "退出"])
+        XCTAssertFalse(titles.contains("仪表盘..."))
+        XCTAssertFalse(titles.contains("帮助"))
+    }
+
+    @MainActor
+    func testStatusMenuVisibleItemsAreOrderedForEnglish() {
+        LanguageManager.shared.current = .english
+
+        let titles = visibleMenuTitles(from: AppDelegate().makeStatusMenu())
+
+        XCTAssertEqual(titles, ["Record", "Transcribe Audio File...", "Settings", "Quit"])
+        XCTAssertFalse(titles.contains("Dashboard..."))
+        XCTAssertFalse(titles.contains("Help"))
+    }
+
+    private func visibleMenuTitles(from menu: NSMenu) -> [String] {
+        menu.items
+            .filter { !$0.isSeparatorItem }
+            .map(\.title)
+    }
+}

--- a/Tests/LanguageManagerTests.swift
+++ b/Tests/LanguageManagerTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import AudioWhisper
+
+class LanguageManagerTests: XCTestCase {
+
+    override func tearDown() {
+        // Reset to default
+        UserDefaults.standard.removeObject(forKey: "appLanguage")
+        super.tearDown()
+    }
+
+    // MARK: - AppLanguage
+
+    func testAppLanguageCases() {
+        XCTAssertEqual(AppLanguage.allCases.count, 2)
+        XCTAssertTrue(AppLanguage.allCases.contains(.english))
+        XCTAssertTrue(AppLanguage.allCases.contains(.chinese))
+    }
+
+    func testAppLanguageRawValues() {
+        XCTAssertEqual(AppLanguage.english.rawValue, "en")
+        XCTAssertEqual(AppLanguage.chinese.rawValue, "zh")
+    }
+
+    func testAppLanguageDisplayNames() {
+        XCTAssertEqual(AppLanguage.english.displayName, "English")
+        XCTAssertEqual(AppLanguage.chinese.displayName, "中文")
+    }
+
+    func testAppLanguageFromRawValue() {
+        XCTAssertEqual(AppLanguage(rawValue: "en"), .english)
+        XCTAssertEqual(AppLanguage(rawValue: "zh"), .chinese)
+        XCTAssertNil(AppLanguage(rawValue: "fr"))
+    }
+
+    // MARK: - LanguageManager persistence
+
+    func testLanguageManagerDefaultsToEnglish() {
+        UserDefaults.standard.removeObject(forKey: "appLanguage")
+        let manager = LanguageManager.shared
+        // After removing, the shared instance may still retain its value,
+        // so just verify it's a valid language
+        XCTAssertNotNil(manager.current)
+    }
+
+    func testLanguageManagerPersistsChoice() {
+        let manager = LanguageManager.shared
+        manager.current = .chinese
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "appLanguage"), "zh")
+
+        manager.current = .english
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "appLanguage"), "en")
+    }
+
+    // MARK: - L10n bilingual strings
+
+    func testL10nEnglishStrings() {
+        LanguageManager.shared.current = .english
+
+        XCTAssertEqual(L10n.Nav.overview, "Overview")
+        XCTAssertEqual(L10n.Nav.transcripts, "Transcripts")
+        XCTAssertEqual(L10n.Home.thisMonth, "This Month")
+        XCTAssertEqual(L10n.Home.words, "Words")
+        XCTAssertEqual(L10n.Home.activityFooter, "Words transcribed across all saved records.")
+        XCTAssertEqual(L10n.Home.viewAll, "View All…")
+        XCTAssertEqual(L10n.Home.noTranscripts, "No transcripts yet.")
+        XCTAssertEqual(L10n.Home.streakDays(1), "1 day")
+        XCTAssertEqual(L10n.Home.streakDays(5), "5 days")
+        XCTAssertEqual(L10n.Menu.record, "Record")
+        XCTAssertEqual(L10n.Menu.transcribeAudioFile, "Transcribe Audio File...")
+        XCTAssertEqual(L10n.Menu.dashboard, "Dashboard...")
+        XCTAssertEqual(L10n.Menu.settings, "Settings...")
+        XCTAssertEqual(L10n.Menu.help, "Help")
+        XCTAssertEqual(L10n.Menu.quit, "Quit")
+        XCTAssertEqual(L10n.Categories.categoryTypes, "Category Types")
+        XCTAssertEqual(L10n.Categories.name(for: "coding", fallback: ""), "Coding")
+        XCTAssertEqual(L10n.Categories.promptDescription(for: "terminal", fallback: ""), "Preserves CLI terms, flags, paths. Fixes: 'suit oh' → 'sudo', 'see dee' → 'cd'")
+        XCTAssertEqual(L10n.Recording.preparingAudio, "Preparing audio...")
+        XCTAssertEqual(L10n.Preferences.language, "Language")
+        XCTAssertEqual(L10n.Common.cancel, "Cancel")
+        XCTAssertEqual(L10n.Common.save, "Save")
+    }
+
+    func testL10nChineseStrings() {
+        LanguageManager.shared.current = .chinese
+
+        XCTAssertEqual(L10n.Nav.overview, "总览")
+        XCTAssertEqual(L10n.Nav.transcripts, "转录记录")
+        XCTAssertEqual(L10n.Home.thisMonth, "本月统计")
+        XCTAssertEqual(L10n.Home.words, "字数")
+        XCTAssertEqual(L10n.Home.activityFooter, "全部已保存记录的转录字数")
+        XCTAssertEqual(L10n.Home.viewAll, "查看全部…")
+        XCTAssertEqual(L10n.Home.noTranscripts, "暂无转录记录")
+        XCTAssertEqual(L10n.Home.streakDays(5), "5 天")
+        XCTAssertEqual(L10n.Menu.record, "录音")
+        XCTAssertEqual(L10n.Menu.transcribeAudioFile, "转录音频文件...")
+        XCTAssertEqual(L10n.Menu.dashboard, "仪表盘...")
+        XCTAssertEqual(L10n.Menu.settings, "偏好设置...")
+        XCTAssertEqual(L10n.Menu.help, "帮助")
+        XCTAssertEqual(L10n.Menu.quit, "退出")
+        XCTAssertEqual(L10n.Categories.categoryTypes, "分类类型")
+        XCTAssertEqual(L10n.Categories.appAssignments, "应用分配")
+        XCTAssertEqual(L10n.Categories.systemBadge, "系统")
+        XCTAssertEqual(L10n.Categories.name(for: "coding", fallback: ""), "编程")
+        XCTAssertTrue(L10n.Categories.promptDescription(for: "terminal", fallback: "").contains("保留 CLI 术语"))
+        XCTAssertEqual(L10n.Recording.preparingAudio, "准备音频...")
+        XCTAssertEqual(L10n.Preferences.language, "语言")
+        XCTAssertEqual(L10n.Common.cancel, "取消")
+        XCTAssertEqual(L10n.Common.save, "保存")
+    }
+
+    func testSystemCategoryDisplayIsLocalized() {
+        let coding = CategoryDefinition.defaults.first { $0.id == "coding" }!
+
+        LanguageManager.shared.current = .english
+        XCTAssertEqual(coding.localizedDisplayName, "Coding")
+        XCTAssertTrue(coding.localizedPromptDescription.contains("Preserves syntax"))
+
+        LanguageManager.shared.current = .chinese
+        XCTAssertEqual(coding.localizedDisplayName, "编程")
+        XCTAssertTrue(coding.localizedPromptDescription.contains("保留语法"))
+    }
+
+    func testL10nProviderDisplayName() {
+        LanguageManager.shared.current = .english
+        XCTAssertEqual(L10n.Provider.displayName(for: "openai"), "OpenAI")
+        XCTAssertEqual(L10n.Provider.displayName(for: "local"), "Local Whisper")
+        XCTAssertEqual(L10n.Provider.displayName(for: "funasr"), "FunASR")
+
+        LanguageManager.shared.current = .chinese
+        XCTAssertEqual(L10n.Provider.displayName(for: "local"), "本地 Whisper")
+        // OpenAI and FunASR don't change
+        XCTAssertEqual(L10n.Provider.displayName(for: "openai"), "OpenAI")
+    }
+
+    func testL10nFormatDuration() {
+        LanguageManager.shared.current = .english
+        XCTAssertEqual(L10n.Format.duration(0), "0m")
+        XCTAssertEqual(L10n.Format.duration(300), "5m")
+        XCTAssertEqual(L10n.Format.duration(3660), "1h 1m")
+
+        LanguageManager.shared.current = .chinese
+        XCTAssertEqual(L10n.Format.duration(0), "0 分钟")
+        XCTAssertEqual(L10n.Format.duration(300), "5 分钟")
+        XCTAssertEqual(L10n.Format.duration(3660), "1 小时 1 分钟")
+    }
+
+    func testL10nWeekdays() {
+        LanguageManager.shared.current = .english
+        XCTAssertEqual(L10n.Weekday.short.count, 7)
+        XCTAssertEqual(L10n.Weekday.short.first, "S")
+
+        LanguageManager.shared.current = .chinese
+        XCTAssertEqual(L10n.Weekday.short.count, 7)
+        XCTAssertEqual(L10n.Weekday.short.first, "日")
+    }
+
+    func testL10nRecordRowAccessibility() {
+        LanguageManager.shared.current = .english
+        let label = L10n.RecordRow.accessibilityLabel(date: "Mar 14", provider: "openai")
+        XCTAssertTrue(label.contains("Mar 14"))
+        XCTAssertTrue(label.contains("openai"))
+
+        LanguageManager.shared.current = .chinese
+        let labelCN = L10n.RecordRow.accessibilityLabel(date: "3月14日", provider: "openai")
+        XCTAssertTrue(labelCN.contains("3月14日"))
+        XCTAssertTrue(labelCN.contains("转录于"))
+    }
+}

--- a/Tests/LanguageManagerTests.swift
+++ b/Tests/LanguageManagerTests.swift
@@ -68,13 +68,11 @@ class LanguageManagerTests: XCTestCase {
         XCTAssertEqual(L10n.Home.streakDays(5), "5 days")
         XCTAssertEqual(L10n.Menu.record, "Record")
         XCTAssertEqual(L10n.Menu.transcribeAudioFile, "Transcribe Audio File...")
-        XCTAssertEqual(L10n.Menu.dashboard, "Dashboard...")
-        XCTAssertEqual(L10n.Menu.settings, "Settings...")
-        XCTAssertEqual(L10n.Menu.help, "Help")
+        XCTAssertEqual(L10n.Menu.settings, "Settings")
         XCTAssertEqual(L10n.Menu.quit, "Quit")
         XCTAssertEqual(L10n.Categories.categoryTypes, "Category Types")
         XCTAssertEqual(L10n.Categories.name(for: "coding", fallback: ""), "Coding")
-        XCTAssertEqual(L10n.Categories.promptDescription(for: "terminal", fallback: ""), "Preserves CLI terms, flags, paths. Fixes: 'suit oh' → 'sudo', 'see dee' → 'cd'")
+        XCTAssertEqual(L10n.Categories.promptDescription(for: "terminal", fallback: ""), "Preserves CLI, GitHub, repo, deploy, monitoring terms, flags, and paths")
         XCTAssertEqual(L10n.Recording.preparingAudio, "Preparing audio...")
         XCTAssertEqual(L10n.Preferences.language, "Language")
         XCTAssertEqual(L10n.Common.cancel, "Cancel")
@@ -94,15 +92,13 @@ class LanguageManagerTests: XCTestCase {
         XCTAssertEqual(L10n.Home.streakDays(5), "5 天")
         XCTAssertEqual(L10n.Menu.record, "录音")
         XCTAssertEqual(L10n.Menu.transcribeAudioFile, "转录音频文件...")
-        XCTAssertEqual(L10n.Menu.dashboard, "仪表盘...")
-        XCTAssertEqual(L10n.Menu.settings, "偏好设置...")
-        XCTAssertEqual(L10n.Menu.help, "帮助")
+        XCTAssertEqual(L10n.Menu.settings, "设置")
         XCTAssertEqual(L10n.Menu.quit, "退出")
         XCTAssertEqual(L10n.Categories.categoryTypes, "分类类型")
         XCTAssertEqual(L10n.Categories.appAssignments, "应用分配")
         XCTAssertEqual(L10n.Categories.systemBadge, "系统")
         XCTAssertEqual(L10n.Categories.name(for: "coding", fallback: ""), "编程")
-        XCTAssertTrue(L10n.Categories.promptDescription(for: "terminal", fallback: "").contains("保留 CLI 术语"))
+        XCTAssertTrue(L10n.Categories.promptDescription(for: "terminal", fallback: "").contains("保留 CLI、GitHub"))
         XCTAssertEqual(L10n.Recording.preparingAudio, "准备音频...")
         XCTAssertEqual(L10n.Preferences.language, "语言")
         XCTAssertEqual(L10n.Common.cancel, "取消")
@@ -114,11 +110,11 @@ class LanguageManagerTests: XCTestCase {
 
         LanguageManager.shared.current = .english
         XCTAssertEqual(coding.localizedDisplayName, "Coding")
-        XCTAssertTrue(coding.localizedPromptDescription.contains("Preserves syntax"))
+        XCTAssertTrue(coding.localizedPromptDescription.contains("Preserves code"))
 
         LanguageManager.shared.current = .chinese
         XCTAssertEqual(coding.localizedDisplayName, "编程")
-        XCTAssertTrue(coding.localizedPromptDescription.contains("保留语法"))
+        XCTAssertTrue(coding.localizedPromptDescription.contains("保留代码"))
     }
 
     func testL10nProviderDisplayName() {

--- a/Tests/TextCleaningTests.swift
+++ b/Tests/TextCleaningTests.swift
@@ -81,6 +81,20 @@ final class TextCleaningTests: XCTestCase {
         let result = SpeechToTextService.cleanTranscriptionText(input)
         XCTAssertEqual(result, expected)
     }
+
+    func testTechnicalTermNormalization() {
+        let testCases = [
+            ("open git hub and check the p r", "open GitHub and check the PR"),
+            ("github repo is in open ai", "GitHub repo is in OpenAI"),
+            ("进 Hub 看一下 Chat GPT 的记录", "GitHub 看一下 ChatGPT 的记录"),
+            ("金 hub 里面的 P R", "GitHub 里面的 PR")
+        ]
+
+        for (input, expected) in testCases {
+            let result = SpeechToTextService.cleanTranscriptionText(input)
+            XCTAssertEqual(result, expected, "Failed to normalize: \(input)")
+        }
+    }
     
     func testValidTextPreservation() {
         let input = "This is valid transcription text that should remain unchanged."

--- a/Tests/TranscriptionRecordTests.swift
+++ b/Tests/TranscriptionRecordTests.swift
@@ -176,4 +176,31 @@ final class TranscriptionRecordTests: XCTestCase {
         )
         XCTAssertNil(noModelRecord.whisperModel)
     }
+
+    func testDetailedTimingFields() {
+        let legacyRecord = TranscriptionRecord(
+            text: "Legacy",
+            provider: .openai,
+            transcriptionTime: 2.5
+        )
+        XCTAssertFalse(legacyRecord.hasDetailedTiming)
+
+        let detailedRecord = TranscriptionRecord(
+            text: "Detailed",
+            provider: .openai,
+            transcriptionTime: 2.5,
+            asrTime: 1.4,
+            correctionTime: 0.6,
+            clipboardTime: 0.1,
+            pasteTime: 0.4,
+            endToEndTime: 2.8
+        )
+
+        XCTAssertTrue(detailedRecord.hasDetailedTiming)
+        XCTAssertEqual(detailedRecord.asrTime, 1.4)
+        XCTAssertEqual(detailedRecord.correctionTime, 0.6)
+        XCTAssertEqual(detailedRecord.clipboardTime, 0.1)
+        XCTAssertEqual(detailedRecord.pasteTime, 0.4)
+        XCTAssertEqual(detailedRecord.endToEndTime, 2.8)
+    }
 }

--- a/Tests/UsageMetricsStoreTests.swift
+++ b/Tests/UsageMetricsStoreTests.swift
@@ -127,6 +127,12 @@ private final class TestDataManager: DataManagerProtocol {
         records.removeAll()
     }
 
+    func updateTiming(for recordID: UUID, pasteTime: TimeInterval?, endToEndTime: TimeInterval?) async throws {
+        guard let record = records.first(where: { $0.id == recordID }) else { return }
+        record.pasteTime = pasteTime
+        record.endToEndTime = endToEndTime
+    }
+
     func cleanupExpiredRecords() async throws {}
 
     func saveTranscriptionQuietly(_ record: TranscriptionRecord) async {


### PR DESCRIPTION
## Summary
- Rebuild the dashboard overview with all local usage history, calendar activity, source/model breakdowns, recent trends, and Chinese-localized dashboard/category surfaces.
- Preserve historical records by defaulting retention to forever, migrating production history preferences for dev builds, and bootstrapping usage/source metrics from existing records.
- Localize the menu bar status menu, app commands, and audio-file picker prompts through the shared language setting, including live menu refresh when the language changes.
- Add hover details to the Recent Trend chart so each non-empty daily bar reveals date, words, characters, sessions, recording time, and processing time.
- Add a dedicated Timing Analysis page that breaks each transcription run into recording, model preparation, ASR, semantic correction, clipboard, paste, and legacy/untracked processing time, with an include-recording toggle and per-stage distribution.
- Record detailed timing for new transcription runs while keeping old records compatible through legacy total processing time fallback.

## Validation
- `swift build`
- `swift test --filter TranscriptionRecordTests`
- `swift test --filter LanguageManagerTests`
- `swift test --filter UsageMetricsStoreTests`
